### PR TITLE
fix: 单面生成时图像不会被镜像

### DIFF
--- a/core/converter.py
+++ b/core/converter.py
@@ -548,12 +548,12 @@ def convert_image_to_3d(image_path, lut_path, target_width_mm, spacer_thick,
     else:
         total_layers = 5 + spacer_layers
         full_matrix = np.full((total_layers, target_h, target_w), -1, dtype=int)
-        full_matrix[0:5] = bottom_voxels
-
+        top_voxels = np.transpose(best_stacks, (2, 0, 1))
         spacer = np.full((target_h, target_w), -1, dtype=int)
         spacer[~mask_transparent] = 0
-        for z in range(5, total_layers):
+        for z in range(0, spacer_layers):
             full_matrix[z] = spacer
+        full_matrix[spacer_layers:] = top_voxels
 
     # Mesh generation
     scene = trimesh.Scene()


### PR DESCRIPTION
修复了选择`单面 (浮雕)`生成时会导致图像被镜像的问题，解决了#13 提到的问题。修复方式是改用顶面5层而非底面5层。
<img width="663" height="513" alt="ScreenShot_2026-01-21_001411_211" src="https://github.com/user-attachments/assets/79829bdb-3e27-45d3-9aae-12ac2d4f12fb" />
<img width="651" height="570" alt="ScreenShot_2026-01-21_001355_660" src="https://github.com/user-attachments/assets/88b25ad6-5f70-4b0f-8d29-adb01b7615c6" />
