### PR TITLE
[FIX]向requirement文件中添加缺少的colormath库

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ networkx
 lxml
 svglib
 reportlab
+colormath
 # Native Vector Engine dependencies
 svgelements>=1.9.0
 shapely>=2.0.0


### PR DESCRIPTION
requirement文件中缺少colormath库，直接pip requirement文件无法成功运行项目，已修复