### PR TITLE
添加github action file实现预览版自动构建

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         # 获取 7 位短 Hash
         SHORT_SHA=$(git rev-parse --short=7 HEAD | cut -c1-7 || echo "0000000")
         
-        # 组合完整名称 (例如: Lumina-Layers-20260226-4d23c52)
-        FULL_NAME="Lumina-Layers-$VERSION-$SHORT_SHA"
+        # 组合完整名称
+        FULL_NAME="Lumina-Layers-preview-$VERSION-$SHORT_SHA"
         
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV


### PR DESCRIPTION
main分支合并pr时，或收到push时，将会触发构建预览版。

预览版将保存到github actions 的 Artifacts中，不会干扰release页面的版本发布。

预览版以及预览版名称格式为Lumina-Layers-preview-YYYYMMDD-githash的格式。压缩包与exe均为该格式。