### PR TITLE
feat: 颜色匹配从 RGB 欧氏距离切换到 CIELAB 感知均匀空间

### DIFF
--- a/core/converter.py
+++ b/core/converter.py
@@ -542,8 +542,9 @@ def convert_image_to_3d(image_path, lut_path, target_width_mm, spacer_thick,
             orig_mask = np.all(old_rgb == orig_rgb_tuple, axis=-1)
             if not np.any(orig_mask):
                 continue
-            # Query KDTree to find the closest LUT entry for the replacement color
-            _, lut_idx = processor.kdtree.query([repl_rgb_tuple])
+            # Query KDTree to find the closest LUT entry for the replacement color (in CIELAB space)
+            repl_lab = processor._rgb_to_lab(np.array([repl_rgb_tuple], dtype=np.uint8))
+            _, lut_idx = processor.kdtree.query(repl_lab)
             lut_idx = lut_idx[0]
             new_stacks = processor.ref_stacks[lut_idx]  # (COLOR_LAYERS,)
             material_matrix[orig_mask] = new_stacks


### PR DESCRIPTION
# PR: 颜色匹配从 RGB 切换到 CIELAB 感知均匀空间

## 分支

`feature/cielab-color-matching` → `main`

## 问题背景

用户反馈颜色匹配不准确：肉眼看觉得有更近的颜色，但系统却匹配了另一个。

根因：原来的颜色匹配在 RGB 空间中使用欧氏距离做最近邻查找。RGB 空间不是感知均匀的，"数学上最近"的颜色和"人眼看起来最近"的颜色经常不一致。

## 解决方案

将颜色匹配的距离计算从 RGB 空间切换到 CIELAB 空间。CIELAB 是专为感知均匀性设计的色彩空间，其欧氏距离与人眼感知差异高度一致。

匹配结果仍然返回 `lut_rgb`（预览和 3MF 输出不受影响），仅查找过程在 Lab 空间进行。

## 改动文件

### `core/image_processing.py`（+42 -10）

1. **新增 `_rgb_to_lab` 静态方法**：使用 OpenCV `cvtColor` 做 RGB→BGR→Lab 转换，支持 `(N,3)` 和 `(H,W,3)` 两种输入 shape
2. **`__init__`**：新增 `self.lut_lab` 属性，存储 Lab 空间的 LUT 颜色
3. **`_load_lut`**：所有分支（.npz 直接加载、companion .npz、末尾统一构建）的 KDTree 改为基于 `lut_lab` 构建
4. **`_process_high_fidelity_mode`**：量化后的 `unique_colors` 先转 Lab 再查询 KDTree
5. **`_process_pixel_mode`**：逐像素 `flat_rgb` 先转 Lab 再查询 KDTree

### `core/converter.py`（+3 -2）

6. **`convert_image_to_3d` 颜色替换部分**：替换颜色先通过 `_rgb_to_lab` 转为 Lab 再查询 KDTree

## 性能影响

极小。仅在以下时机多一次 `cv2.cvtColor` 调用：

- LUT 加载时（一次性，几百到几千个颜色）
- High-Fidelity 模式匹配时（仅对 unique_colors，通常 < 100 个）
- Pixel Art 模式匹配时（逐像素，但 cvtColor 是批量操作，很快）

## 测试

78 个测试全部通过，零失败。

```
78 passed in 30.44s
```

## Commit

```
dd995ed feat: 颜色匹配从 RGB 欧氏距离切换到 CIELAB 感知均匀空间
```
