### PR TITLE
fix: 稳定 SVG 矢量链路并完善平台行为

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import platform
 from enum import Enum
 
 # Handle PyInstaller bundled resources
@@ -255,3 +256,41 @@ class VectorConfig:
     # Parallel processing
     ENABLE_PARALLEL: bool = False      # Parallel layer processing (experimental)
     MAX_WORKERS: int = 5               # Thread pool size
+
+
+# ========== Runtime Platform Policy ==========
+
+def _env_flag(name: str) -> bool:
+    """Return True for common truthy env var values."""
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def is_wsl_runtime() -> bool:
+    """Detect whether current runtime is WSL."""
+    if "WSL_DISTRO_NAME" in os.environ or "WSL_INTEROP" in os.environ:
+        return True
+    try:
+        return "microsoft" in platform.release().lower()
+    except Exception:
+        return False
+
+
+def get_tray_runtime_policy():
+    """Return (enabled, reason) for system tray initialization."""
+    if _env_flag("DISABLE_TRAY"):
+        return False, "Disabled by DISABLE_TRAY environment variable"
+
+    if is_wsl_runtime():
+        return False, "Disabled on WSL environment"
+
+    # Linux desktop tray support is inconsistent across distros/DEs.
+    # Keep it opt-in to avoid startup noise.
+    if sys.platform.startswith("linux"):
+        if _env_flag("ENABLE_TRAY"):
+            return True, "Enabled on Linux via ENABLE_TRAY=1"
+        return False, "Disabled on Linux by default (set ENABLE_TRAY=1 to force)"
+
+    if os.name == "nt" or sys.platform == "darwin":
+        return True, "Enabled on desktop platform"
+
+    return False, f"Disabled on unsupported platform: {sys.platform}"

--- a/core/converter.py
+++ b/core/converter.py
@@ -5,6 +5,7 @@ Coordinates modules to complete image-to-3D model conversion.
 """
 
 import os
+import time
 from collections import deque
 import numpy as np
 import cv2
@@ -330,8 +331,13 @@ def _resolve_click_selection_hexes(cache, default_hex):
     显示色优先使用原配准色，内部状态色保持量化色，
     以兼容“显示原图色、替换按量化色作用连通域”的设计。
     """
-    q_hex = (cache or {}).get('selected_quantized_hex') or default_hex
-    m_hex = (cache or {}).get('selected_matched_hex') or q_hex
+    cached_q_hex = (cache or {}).get('selected_quantized_hex')
+    cached_m_hex = (cache or {}).get('selected_matched_hex')
+
+    # Gradio update objects are dict-like; they must not propagate into hex state.
+    fallback_hex = default_hex if isinstance(default_hex, str) else None
+    q_hex = cached_q_hex if isinstance(cached_q_hex, str) else fallback_hex
+    m_hex = cached_m_hex if isinstance(cached_m_hex, str) else q_hex
     return m_hex, q_hex
 
 
@@ -542,6 +548,8 @@ def convert_image_to_3d(image_path, lut_path, target_width_mm, spacer_thick,
     # Check if user selected vector mode AND file is SVG
     if modeling_mode == ModelingMode.VECTOR and image_path.lower().endswith('.svg'):
         print("[CONVERTER] 🎨 Using Native Vector Engine (Shapely/Clipper)...")
+        vector_timing = {}
+        vector_total_t0 = time.perf_counter()
 
         vector_replacements = _normalize_color_replacements_input(replacement_regions)
         if not vector_replacements:
@@ -554,6 +562,7 @@ def convert_image_to_3d(image_path, lut_path, target_width_mm, spacer_thick,
             vec_processor = VectorProcessor(actual_lut_path, color_mode)
 
             # Convert SVG to 3D scene
+            mesh_t0 = time.perf_counter()
             scene = vec_processor.svg_to_mesh(
                 svg_path=image_path,
                 target_width_mm=target_width_mm,
@@ -561,31 +570,91 @@ def convert_image_to_3d(image_path, lut_path, target_width_mm, spacer_thick,
                 structure_mode=structure_mode,
                 color_replacements=vector_replacements
             )
+            vector_timing["mesh_total_s"] = time.perf_counter() - mesh_t0
+            if isinstance(getattr(vec_processor, "last_stage_timings", None), dict):
+                vector_timing.update(vec_processor.last_stage_timings)
+
+            # Keep vector export behavior consistent with raster path:
+            # never export an empty scene.
+            if len(scene.geometry) == 0:
+                return None, None, None, "❌ Vector mesh generation failed: no valid geometry generated"
             
-            # 2. Export 3MF
+            # 2. Export 3MF (unified Bambu metadata path)
             base_name = os.path.splitext(os.path.basename(image_path))[0]
             out_path = os.path.join(OUTPUT_DIR, generate_model_filename(base_name, modeling_mode, color_mode))
-            scene.export(out_path)
-            
-            # [CRITICAL FIX] Disable safe_fix_3mf_names for Vector Mode
-            # Vector engine assigns names internally. External fixing causes index shifts
-            # if layers are missing (e.g., skipping Green causes Yellow to be named Green).
-            # safe_fix_3mf_names(out_path, color_conf['slots'])  # <-- DISABLED
-            
-            print(f"[CONVERTER] ✅ Vector 3MF exported: {out_path}")
+
+            is_six_color = len(vec_processor.img_processor.lut_rgb) == 1296
+            if is_six_color:
+                vec_color_conf = ColorSystem.SIX_COLOR
+                vec_color_mode = "6-Color"
+            else:
+                vec_color_conf = ColorSystem.get(color_mode)
+                vec_color_mode = color_mode
+
+            vec_slot_names = []
+            for geom_name, geom in scene.geometry.items():
+                vertices = getattr(geom, "vertices", None)
+                faces = getattr(geom, "faces", None)
+                v_count = len(vertices) if vertices is not None else 0
+                f_count = len(faces) if faces is not None else 0
+                if v_count == 0 or f_count == 0:
+                    print(f"[CONVERTER] Skipping empty vector geometry '{geom_name}' (v={v_count}, f={f_count})")
+                    continue
+                vec_slot_names.append(geom_name)
+
+            if not vec_slot_names:
+                return None, None, None, "❌ Vector export aborted: all generated geometries are empty"
+            vec_preview_colors = vec_color_conf['preview']
+
+            vec_print_settings = {
+                'layer_height': '0.08',
+                'initial_layer_height': '0.08',
+                'wall_loops': '1',
+                'top_shell_layers': '0',
+                'bottom_shell_layers': '0',
+                'sparse_infill_density': '100%',
+                'sparse_infill_pattern': 'zig-zag',
+                'nozzle_temperature': ['220'] * 8,
+                'bed_temperature': ['60'] * 8,
+                'filament_type': ['PLA'] * 8,
+                'print_speed': '100',
+                'travel_speed': '150',
+                'enable_support': '0',
+                'brim_width': '5',
+                'brim_type': 'auto_brim',
+            }
+
+            export_t0 = time.perf_counter()
+            export_scene_with_bambu_metadata(
+                scene=scene,
+                output_path=out_path,
+                slot_names=vec_slot_names,
+                preview_colors=vec_preview_colors,
+                settings=vec_print_settings,
+                color_mode=vec_color_mode,
+            )
+            vector_timing["export_3mf_s"] = time.perf_counter() - export_t0
+
+            print(f"[CONVERTER] Vector 3MF exported with Bambu metadata: {out_path}")
             
             # 4. Generate GLB Preview
             glb_path = None
+            glb_t0 = time.perf_counter()
             try:
                 glb_path = os.path.join(OUTPUT_DIR, generate_preview_filename(base_name))
                 scene.export(glb_path)
                 print(f"[CONVERTER] ✅ Preview GLB exported: {glb_path}")
             except Exception as e:
                 print(f"[CONVERTER] Warning: Preview generation skipped: {e}")
+            vector_timing["export_glb_s"] = time.perf_counter() - glb_t0
             
             # 5. [FIX] Generate 2D Preview Image from SVG
             preview_img = None
-            if HAS_SVG_LIB:
+            preview_t0 = time.perf_counter()
+            skip_heavy_preview = os.getenv("LUMINA_VECTOR_SKIP_2D_PREVIEW", "0") == "1"
+            if skip_heavy_preview:
+                print("[CONVERTER] Skipping SVG 2D preview due to LUMINA_VECTOR_SKIP_2D_PREVIEW=1")
+            elif HAS_SVG_LIB:
                 try:
                     # Use SVG-safe rasterization with bounds normalization
                     preview_rgba = vec_processor.img_processor._load_svg(image_path, target_width_mm)
@@ -654,9 +723,28 @@ def convert_image_to_3d(image_path, lut_path, target_width_mm, spacer_thick,
                     print(f"[CONVERTER] Failed to render SVG preview: {e}")
             else:
                 print("[CONVERTER] svglib not installed, skipping 2D preview")
+            vector_timing["preview_2d_s"] = time.perf_counter() - preview_t0
             
             # Update stats
             Stats.increment("conversions")
+
+            vector_timing["vector_branch_total_s"] = time.perf_counter() - vector_total_t0
+            if vector_timing:
+                print(
+                    "[CONVERTER] Vector timings (s): "
+                    f"parse={vector_timing.get('parse_s', 0.0):.3f}, "
+                    f"clip={vector_timing.get('occlusion_s', 0.0):.3f}, "
+                    f"match={vector_timing.get('color_match_s', 0.0):.3f}, "
+                    f"extrude_bottom={vector_timing.get('extrude_bottom_s', 0.0):.3f}, "
+                    f"backing={vector_timing.get('backing_s', 0.0):.3f}, "
+                    f"extrude_top={vector_timing.get('extrude_top_s', 0.0):.3f}, "
+                    f"assemble={vector_timing.get('assemble_s', 0.0):.3f}, "
+                    f"mesh_total={vector_timing.get('mesh_total_s', 0.0):.3f}, "
+                    f"export_3mf={vector_timing.get('export_3mf_s', 0.0):.3f}, "
+                    f"export_glb={vector_timing.get('export_glb_s', 0.0):.3f}, "
+                    f"preview_2d={vector_timing.get('preview_2d_s', 0.0):.3f}, "
+                    f"total={vector_timing.get('vector_branch_total_s', 0.0):.3f}"
+                )
             
             # Return results
             msg = f"✅ Vector conversion complete! Objects merged by material."
@@ -3181,7 +3269,7 @@ def on_preview_click_select_color(cache, evt: gr.SelectData, bed_label=None):
         return None, "未选择", None, "❌ 请先生成预览"
 
     if evt is None or evt.index is None:
-        return gr.update(), gr.update(), gr.update(), "⚠️ 无效点击"
+        return gr.update(), "未选择", None, "⚠️ 无效点击"
 
     if bed_label is None:
         bed_label = cache.get('bed_label', BedManager.DEFAULT_BED)
@@ -3193,7 +3281,7 @@ def on_preview_click_select_color(cache, evt: gr.SelectData, bed_label=None):
     target_width_mm = cache.get('target_width_mm')
 
     if target_w is None or target_h is None:
-        return gr.update(), gr.update(), gr.update(), "❌ 缓存数据不完整"
+        return gr.update(), "未选择", None, "❌ 缓存数据不完整"
 
     bed_w_mm, bed_h_mm = BedManager.get_bed_size(bed_label)
     ppm = BedManager.compute_scale(bed_w_mm, bed_h_mm)
@@ -3243,10 +3331,10 @@ def on_preview_click_select_color(cache, evt: gr.SelectData, bed_label=None):
     h, w = matched_rgb.shape[:2]
 
     if not (0 <= orig_x < w and 0 <= orig_y < h):
-        return gr.update(), gr.update(), gr.update(), f"⚠️ 点击了无效区域 ({orig_x}, {orig_y})"
+        return gr.update(), "未选择", None, f"⚠️ 点击了无效区域 ({orig_x}, {orig_y})"
 
     if not mask_solid[orig_y, orig_x]:
-        return gr.update(), gr.update(), gr.update(), "⚠️ 点击了背景区域"
+        return gr.update(), "未选择", None, "⚠️ 点击了背景区域"
 
     q_rgb = tuple(int(v) for v in quantized_image[orig_y, orig_x])
     m_rgb = tuple(int(v) for v in matched_rgb[orig_y, orig_x])
@@ -3541,7 +3629,7 @@ def detect_image_type(image_path):
         image_path: 图像文件路径
     
     Returns:
-        str: 建模模式 ("🎨 High-Fidelity (Smooth)", "📐 SVG Mode") 或 None
+        ModelingMode or None: 推荐的建模模式枚举值，或 None（不切换）
     """
     if not image_path:
         return None
@@ -3552,7 +3640,7 @@ def detect_image_type(image_path):
         
         if ext == '.svg':
             print(f"[AUTO_DETECT] SVG file detected, recommending SVG Mode")
-            return "📐 SVG Mode"
+            return ModelingMode.VECTOR
         else:
             print(f"[AUTO_DETECT] Raster image detected ({ext}), keeping current mode")
             return None  # 不自动切换光栅图像模式

--- a/core/vector_engine.py
+++ b/core/vector_engine.py
@@ -1,118 +1,125 @@
 """
-Lumina Studio - Native Vector Engine
+Lumina Studio - Native Vector Engine (v2 - Chroma-aligned)
 
-Handles direct SVG to 3D mesh conversion using vector math (Shapely/Clipper)
-instead of rasterization. This preserves smooth curves and sharp edges.
+SVG to 3D mesh conversion using vector geometry operations.
+Aligned with ChromaPrint3D's processing philosophy:
 
-Architecture:
-    SVG → Parse Paths → Match Colors → Boolean Ops → Extrude → Silhouette Backing → 3MF
+Pipeline:
+    SVG → Parse Paths → Occlusion Clip → Match Colors → Run-Length Extrude
+        → Silhouette Backing → (optional Double-sided) → Assemble Scene
 
-Key Features:
-    - Direct path processing (no rasterization)
-    - Boolean operations via Shapely (equivalent to Clipper)
-    - Smooth curve preservation
-    - Automatic color matching to LUT
-    - Mesh merging by material
-    - Coordinate system correction (Y-axis flip)
-    - Accurate silhouette backing (union of all shapes)
-    - Double-sided structure support
+Key changes from v1:
+    - Per-shape reverse-order occlusion clipping (no "small feature" exemptions)
+    - Per-unique-color recipe caching via LUT KDTree
+    - Run-length layer extrusion (consecutive same-channel layers merged)
+    - No micro Z-offset between overlapping colors on the same material
+    - Output objects sorted by material ID for stable slicer ordering
 """
 
 import numpy as np
+import time
 import trimesh
 from svgelements import SVG, Path, Shape
 from shapely.geometry import Polygon, MultiPolygon
-from shapely import affinity  # <--- 【新增】用于几何变换
+from shapely import affinity
 from shapely.ops import unary_union
-import os
 
 from config import PrinterConfig, ColorSystem
 
-# Reuse image processor for color matching infrastructure
-from core.image_processing import LuminaImageProcessor
+# Lazy import to avoid circular dependency at module load time
+_LuminaImageProcessor = None
+
+
+def _get_image_processor_class():
+    global _LuminaImageProcessor
+    if _LuminaImageProcessor is None:
+        from core.image_processing import LuminaImageProcessor
+        _LuminaImageProcessor = LuminaImageProcessor
+    return _LuminaImageProcessor
 
 
 class VectorProcessor:
     """
     Native vector processing engine for SVG files.
-    
-    This class provides direct SVG-to-3D conversion without rasterization,
-    preserving vector precision and smooth curves.
-    
+
+    Converts SVG directly to 3D meshes without rasterization,
+    preserving vector precision.  Uses ChromaPrint3D-style
+    occlusion clipping and run-length layer extrusion.
+
     Attributes:
-        color_mode (str): Color system mode (CMYW/RYBW/6-Color)
-        img_processor (LuminaImageProcessor): For LUT color matching
-        sampling_precision (float): Curve approximation precision in mm
-    
-    Example:
-        >>> processor = VectorProcessor("my_lut.npy", "CMYW")
-        >>> scene = processor.svg_to_mesh("logo.svg", 50.0, 1.6, "Double-sided")
-        >>> scene.export("output.3mf")
+        color_mode: Color system mode string forwarded to ColorSystem.
+        img_processor: LuminaImageProcessor instance for LUT / KDTree access.
+        sampling_precision: Curve approximation precision in mm.
     """
-    
+
     def __init__(self, lut_path: str, color_mode: str):
-        """
-        Initialize vector processor with LUT and color mode.
-        
-        Args:
-            lut_path: Path to .npy LUT file
-            color_mode: Color system ("CMYW", "RYBW", or "6-Color")
-            
-        Raises:
-            FileNotFoundError: If LUT file doesn't exist
-            ValueError: If color mode is invalid
-        """
         self.color_mode = color_mode
         print(f"[VECTOR] Initializing Native Vector Engine ({color_mode})...")
-        
-        # Reuse ImageProcessor for LUT loading and KD-Tree
-        # We only use its color matching infrastructure, not image processing
-        self.img_processor = LuminaImageProcessor(lut_path, color_mode)
-        
-        # Default curve approximation precision
-        self.sampling_precision = 0.05  # mm (high quality)
-        
-        print(f"[VECTOR] ✅ Initialized with {len(self.img_processor.ref_stacks)} LUT colors")
 
-    def svg_to_mesh(self, svg_path: str, target_width_mm: float, 
-                    thickness_mm: float, structure_mode: str = "Single-sided",
-                    color_replacements: dict = None) -> trimesh.Scene:
-        """
-        Convert SVG file to 3D mesh scene.
-        
-        This is the main entry point for vector processing. It orchestrates
-        the entire pipeline from SVG parsing to 3D mesh generation.
-        
+        ImageProcessor = _get_image_processor_class()
+        self.img_processor = ImageProcessor(lut_path, color_mode)
+        self.sampling_precision = 0.05  # mm
+        self.last_stage_timings = {}
+
+        print(f"[VECTOR] Initialized with {len(self.img_processor.ref_stacks)} LUT colors")
+
+    # ── Public entry point ───────────────────────────────────────────────
+
+    def svg_to_mesh(
+        self,
+        svg_path: str,
+        target_width_mm: float,
+        thickness_mm: float,
+        structure_mode: str = "Single-sided",
+        color_replacements: dict = None,
+    ) -> trimesh.Scene:
+        """Convert an SVG file to a trimesh Scene ready for 3MF export.
+
         Args:
-            svg_path: Path to SVG file
-            target_width_mm: Target width in millimeters
-            thickness_mm: Backing layer thickness in mm
-            structure_mode: "Single-sided" or "Double-sided" (双面/单面)
-            
+            svg_path:         Path to SVG file.
+            target_width_mm:  Physical width in mm for the output model.
+            thickness_mm:     Backing (spacer) thickness in mm.
+            structure_mode:   "Single-sided" or "Double-sided".
+            color_replacements: Optional ``{hex: hex}`` replacement map.
+
         Returns:
-            trimesh.Scene: Complete 3D scene with all meshes
-            
-        Raises:
-            ValueError: If SVG parsing fails or no valid shapes found
-            
-        Example:
-            >>> processor = VectorProcessor("lut.npy", "CMYW")
-            >>> scene = processor.svg_to_mesh("logo.svg", 50.0, 1.6, "Double-sided")
-            >>> scene.export("output.3mf")
+            A ``trimesh.Scene`` with one geometry per material slot, sorted
+            by material ID.  Geometry names match slot names from the active
+            ``ColorSystem`` configuration.
         """
         print(f"[VECTOR] Processing: {svg_path}")
         print(f"[VECTOR] Structure mode: {structure_mode}")
-        
-        # Step 1: Parse SVG and extract shapes
+        stage_timings = {}
+        t_total_start = time.perf_counter()
+
+        # === Stage 1: Parse SVG (preserving draw order) ===
+        t0 = time.perf_counter()
         shape_data, scale_factor, bbox = self._parse_svg(svg_path, target_width_mm)
-        
         if not shape_data:
             raise ValueError("No valid filled shapes found in SVG.")
-        
-        print(f"[VECTOR] Found {len(shape_data)} valid shapes. Scale: {scale_factor:.4f}")
-        
-        # Step 2: Group shapes by SVG color (NOT by LUT material yet)
-        # This allows us to handle overlapping shapes correctly
+        stage_timings["parse_s"] = time.perf_counter() - t0
+        print(f"[VECTOR] Parsed {len(shape_data)} shapes. Scale: {scale_factor:.4f}")
+
+        # === Stage 2: Occlusion clip ===
+        t0 = time.perf_counter()
+        clipped_shapes, silhouette = self._clip_occlusion(shape_data, return_silhouette=True)
+        stage_timings["occlusion_s"] = time.perf_counter() - t0
+        print(f"[VECTOR] After occlusion clip: {len(clipped_shapes)} non-overlapping shapes")
+
+        # === Stage 3: Resolve color system config ===
+        is_six_color = len(self.img_processor.lut_rgb) == 1296
+        if is_six_color:
+            print("[VECTOR] Auto-detected 6-Color LUT. Forcing 6-Color mode.")
+            color_conf = ColorSystem.SIX_COLOR
+            self.color_mode = "6-Color"
+        else:
+            color_conf = ColorSystem.get(self.color_mode)
+
+        slot_names = color_conf["slots"]
+        preview_colors = color_conf["preview"]
+        num_channels = len(slot_names)
+
+        # === Stage 4: Match fill colors to LUT recipes ===
         replacement_manager = None
         if color_replacements:
             try:
@@ -121,549 +128,486 @@ class VectorProcessor:
             except Exception as e:
                 print(f"[VECTOR] Warning: Failed to load color replacements: {e}")
 
-        # Group by original SVG color first
-        color_groups = {}  # {svg_color: [polygons]}
-        color_order = []  # Track the order colors first appear in SVG
-        
-        for item in shape_data:
-            color_key = item['color']
-            if color_key not in color_groups:
-                color_groups[color_key] = []
-                color_order.append(color_key)  # Preserve SVG order
-            color_groups[color_key].append(item['poly'])
-        
-        print(f"[VECTOR] Found {len(color_groups)} unique SVG colors")
-        
-        # Perform Boolean operations between different colors
-        # Key insight: In SVG, later elements are drawn ON TOP
-        # So later colors should NOT be subtracted - they stay complete
-        # Earlier colors should have holes cut by later colors
-        # BUT: Small features (< 100 sq units) are preserved without subtraction
-        
-        print(f"[VECTOR] Processing {len(color_order)} colors in SVG order:")
-        for c in color_order:
-            hex_color = f'#{c[0]:02x}{c[1]:02x}{c[2]:02x}'
-            num_shapes = len(color_groups[c])
-            print(f"  {hex_color}: {num_shapes} shapes")
-        
-        final_geometries = {}  # {svg_color: final_geometry}
-        
-        # First pass: merge all polygons of each color and calculate areas
-        merged_colors = {}
-        for current_color in color_order:
-            merged = self._perform_boolean_union(color_groups[current_color])
-            if merged is not None and not merged.is_empty:
-                merged_colors[current_color] = merged
-        
-        # Second pass: perform Boolean operations, but protect small features
-        for i, current_color in enumerate(color_order):
-            if current_color not in merged_colors:
-                continue
-                
-            merged = merged_colors[current_color]
-            area = merged.area
-            hex_color = f'#{current_color[0]:02x}{current_color[1]:02x}{current_color[2]:02x}'
-            
-            # Small features are protected from Boolean subtraction
-            is_small_feature = area < 100
-            
-            if is_small_feature:
-                print(f"  {hex_color}: area={area:.2f} sq units ⭐ SMALL FEATURE - PROTECTED")
-                final_geometries[current_color] = merged
-                continue
-            
-            # For larger features, subtract from earlier colors
-            for j in range(i):
-                earlier_color = color_order[j]
-                if earlier_color not in final_geometries:
-                    continue
-                earlier_geom = final_geometries[earlier_color]
-                
-                if earlier_geom is not None and not earlier_geom.is_empty:
-                    try:
-                        # Remove the part of earlier color that overlaps with current color
-                        final_geometries[earlier_color] = earlier_geom.difference(merged)
-                    except Exception as e:
-                        print(f"[VECTOR] Warning: Boolean difference failed: {e}")
-            
-            # Current color stays complete
-            print(f"  {hex_color}: area={area:.2f} sq units")
-            final_geometries[current_color] = merged
-        
-        print(f"[VECTOR] After Boolean operations: {len(final_geometries)} color regions")
-        
-        # Now map each color to LUT and distribute to layers
-        # We need to track the order of colors for proper Z-layering
-        layer_map = {}  # {z_layer: {mat_id: [(geometry, svg_color_index)]}}
-        
-        print(f"[VECTOR] Mapping colors to LUT materials:")
-        for color_index, (svg_color, geometry) in enumerate(final_geometries.items()):
-            # Query LUT for this color (in CIELAB space)
-            query_lab = self.img_processor._rgb_to_lab(np.array([svg_color], dtype=np.uint8))
-            _, index = self.img_processor.kdtree.query(query_lab)
-            
-            # Get matched LUT color
-            matched_rgb = tuple(int(c) for c in self.img_processor.lut_rgb[index[0]])
-            
-            # Get material stack
-            stack = self.img_processor.ref_stacks[index[0]]
-            
-            hex_color = f'#{svg_color[0]:02x}{svg_color[1]:02x}{svg_color[2]:02x}'
-            print(f"  {hex_color} → LUT {matched_rgb} → Materials {stack[:5]}")
-            
-            # Apply replacement if provided
-            if replacement_manager is not None:
-                replacement = replacement_manager.get_replacement(matched_rgb)
-                if replacement is not None:
-                    rep_lab = self.img_processor._rgb_to_lab(np.array([replacement], dtype=np.uint8))
-                    _, rep_index = self.img_processor.kdtree.query(rep_lab)
-                    index = rep_index
-                    stack = self.img_processor.ref_stacks[index[0]]
-                    print(f"    → Replaced with {replacement} → Materials {stack[:5]}")
-            
-            # Distribute to layers with color order tracking
-            num_layers_to_use = min(5, len(stack))
-            for z in range(num_layers_to_use):
-                mat_id = stack[z]
-                
-                if z not in layer_map:
-                    layer_map[z] = {}
-                if mat_id not in layer_map[z]:
-                    layer_map[z][mat_id] = []
-                
-                # Store geometry with its original color index for Z-ordering
-                layer_map[z][mat_id].append((geometry, color_index))
-        
-        # ==================== [关键修复] 强制同步颜色配置 ====================
-        # Check actual LUT size
-        is_six_color = len(self.img_processor.lut_rgb) == 1296  # 6^4 = 1296
-        num_layers = 5
-        
-        if is_six_color:
-            print("[VECTOR] 🧠 Auto-detected 6-Color LUT (1296). Forcing 6-Color mode.")
-            # 强制切换到 6 色配置，覆盖 UI 选择
-            color_conf = ColorSystem.SIX_COLOR
-            self.color_mode = "6-Color"  # 更新内部状态
-        else:
-            # 否则使用 UI 传入的模式
-            color_conf = ColorSystem.get(self.color_mode)
-        
-        # 获取正确的材质名称和预览颜色
-        slot_names = color_conf['slots']
-        preview_colors = color_conf['preview']
-        print(f"[VECTOR] Using config: {len(slot_names)} slots")
-        # ===================================================================
-        
-        # Step 4: Collect all polygons for silhouette backing
-        all_polygons = []
-        for z in range(num_layers):
-            if z not in layer_map:
-                continue
-            for mat_id, geom_list in layer_map[z].items():
-                # Extract just the geometries (ignore color indices)
-                all_polygons.extend([g for g, _ in geom_list])
-        
-        # Step 5: Create silhouette backing
-        print(f"[VECTOR] Creating silhouette backing from {len(all_polygons)} polygons...")
-        silhouette = self._perform_boolean_union(all_polygons)
-        
-        # Step 6: Generate meshes for color layers
-        # Handle multiple SVG colors mapping to same material by using micro Z-offsets
+        t0 = time.perf_counter()
+        matched_shapes = self._match_colors(clipped_shapes, replacement_manager, num_channels)
+        stage_timings["color_match_s"] = time.perf_counter() - t0
+        print(f"[VECTOR] Matched {len(matched_shapes)} shapes to LUT recipes")
+
+        # === Stage 5: Run-length extrude per channel ===
+        num_layers = PrinterConfig.COLOR_LAYERS
         layer_h = PrinterConfig.LAYER_HEIGHT
-        meshes_by_slot = {}
-        
-        # Micro offset for overlapping colors on same material (0.001mm per color)
-        MICRO_OFFSET = 0.001
-        
-        for z in range(num_layers):
-            if z not in layer_map:
-                continue
-            
-            for mat_id, geom_list in layer_map[z].items():
-                if not geom_list:
-                    continue
-                
-                # 安全检查：防止脏数据导致的越界
-                if mat_id >= len(slot_names):
-                    print(f"[VECTOR] ⚠️ Skipping invalid mat_id {mat_id} (max {len(slot_names)-1})")
-                    continue
-                
-                # Sort by color index to maintain SVG order
-                geom_list.sort(key=lambda x: x[1])
-                
-                # Process each geometry separately with micro Z-offset
-                # This prevents small features from being lost in union operations
-                slot_name = slot_names[mat_id]
-                
-                for offset_idx, (geometry, color_idx) in enumerate(geom_list):
-                    if geometry is None or geometry.is_empty:
-                        continue
-                    
-                    # Calculate Z position with micro offset
-                    # Later colors (higher color_idx) get slightly higher Z
-                    current_z = z * layer_h + (offset_idx * MICRO_OFFSET)
-                    
-                    new_meshes = self._extrude_geometry(
-                        geometry, 
-                        height=layer_h, 
-                        z_offset=current_z, 
-                        scale=scale_factor
-                    )
-                    
-                    if len(new_meshes) == 0:
-                        geom_area = geometry.area
-                        print(f"[VECTOR] ⚠️ No meshes generated for mat_id={mat_id}, z={z}, area={geom_area:.2f}")
-                    
-                    if slot_name not in meshes_by_slot:
-                        meshes_by_slot[slot_name] = {'meshes': [], 'mat_id': mat_id}
-                    meshes_by_slot[slot_name]['meshes'].extend(new_meshes)
-        
-        # Step 7: Generate backing layer
-        backing_layers = max(1, int(round(thickness_mm / layer_h)))
+        extrude_cache = {}
+
+        t0 = time.perf_counter()
+        meshes_by_slot = self._run_length_extrude(
+            matched_shapes, num_layers, layer_h, num_channels,
+            slot_names, scale_factor, extrude_cache=extrude_cache,
+        )
+        stage_timings["extrude_bottom_s"] = time.perf_counter() - t0
+
+        # === Stage 6: Backing layer from silhouette ===
+        t0 = time.perf_counter()
+        if silhouette is None and clipped_shapes:
+            # Defensive fallback if union accumulation failed in occlusion stage.
+            all_geoms = [
+                s["geometry"]
+                for s in clipped_shapes
+                if s["geometry"] is not None and not s["geometry"].is_empty
+            ]
+            silhouette = unary_union(all_geoms) if all_geoms else None
+
+        backing_layer_count = max(1, int(round(thickness_mm / layer_h)))
         backing_z_start = num_layers * layer_h
-        
-        if thickness_mm > 0:
-            print(f"[VECTOR] Generating backing: {backing_layers} layers ({thickness_mm}mm)")
+
+        if thickness_mm > 0 and silhouette is not None and not silhouette.is_empty:
+            print(f"[VECTOR] Generating backing: {backing_layer_count} layers ({thickness_mm}mm)")
             backing_meshes = []
-            for i in range(backing_layers):
-                backing_z = backing_z_start + (i * layer_h)
-                backing_mesh_list = self._extrude_geometry(
-                    silhouette,
-                    height=layer_h,
-                    z_offset=backing_z,
-                    scale=scale_factor
-                )
-                backing_meshes.extend(backing_mesh_list)
-            
-            # 背板始终使用 Slot 0 (White)
+            backing_height = backing_layer_count * layer_h
+            backing_meshes.extend(
+                self._extrude_geometry(silhouette, height=backing_height,
+                                       z_offset=backing_z_start, scale=scale_factor,
+                                       extrude_cache=extrude_cache)
+            )
             if backing_meshes:
-                # 确保 "Board" 对象使用正确的白色材质 ID
-                backing_id = 0
-                backing_name = "Board"  # 或者使用 slot_names[0] 比如 "White"
+                backing_name = "Board"
                 if backing_name not in meshes_by_slot:
-                    meshes_by_slot[backing_name] = {'meshes': [], 'mat_id': backing_id}
-                meshes_by_slot[backing_name]['meshes'].extend(backing_meshes)
-        
-        # Step 8: Handle double-sided structure
-        is_double_sided = ("双面" in structure_mode or "Double" in structure_mode)
-        
+                    meshes_by_slot[backing_name] = {"meshes": [], "mat_id": 0}
+                meshes_by_slot[backing_name]["meshes"].extend(backing_meshes)
+        stage_timings["backing_s"] = time.perf_counter() - t0
+
+        # === Stage 7: Double-sided structure ===
+        t0 = time.perf_counter()
+        is_double_sided = "双面" in structure_mode or "Double" in structure_mode
         if is_double_sided:
-            print("[VECTOR] Adding top color layers (double-sided mode)...")
-            top_z_start = backing_z_start + (backing_layers * layer_h)
-            
-            for z in range(num_layers):
-                if z not in layer_map:
-                    continue
-                
-                # Z轴倒序：Face Up (Top layer is Detail)
-                inverted_z = (num_layers - 1) - z
-                current_z = top_z_start + (inverted_z * layer_h)
-                
-                for mat_id, geom_list in layer_map[z].items():
-                    if not geom_list:
-                        continue
-                    if mat_id >= len(slot_names):  # 安全检查
-                        continue
-                    
-                    slot_name = slot_names[mat_id]
-                    
-                    # Sort by color index
-                    geom_list.sort(key=lambda x: x[1])
-                    
-                    # Process each geometry separately with micro Z-offset
-                    for offset_idx, (geometry, color_idx) in enumerate(geom_list):
-                        if geometry is None or geometry.is_empty:
-                            continue
-                        
-                        # Calculate Z position with micro offset
-                        current_z_with_offset = current_z + (offset_idx * MICRO_OFFSET)
-                        
-                        new_meshes = self._extrude_geometry(
-                            geometry,
-                            height=layer_h,
-                            z_offset=current_z_with_offset,
-                            scale=scale_factor
-                        )
-                        
-                        if slot_name in meshes_by_slot:
-                            meshes_by_slot[slot_name]['meshes'].extend(new_meshes)
-        
-        # Step 9: Merge and Assemble
+            print("[VECTOR] Adding mirrored color layers (double-sided mode)...")
+            top_z_start = backing_z_start + backing_layer_count * layer_h
+            self._add_double_sided_layers(
+                matched_shapes, num_layers, layer_h, num_channels,
+                slot_names, scale_factor, top_z_start, meshes_by_slot,
+                extrude_cache=extrude_cache,
+            )
+        stage_timings["extrude_top_s"] = time.perf_counter() - t0
+
+        # === Stage 8: Assemble scene (sorted by material ID) ===
+        t0 = time.perf_counter()
         scene = trimesh.Scene()
         svg_height_mm = bbox[3] * scale_factor
-        
-        # [FIX] Sort by Material ID to ensure consistent order in Slicer
-        # This fixes the "random color order" issue
-        sorted_items = sorted(meshes_by_slot.items(), key=lambda x: x[1]['mat_id'])
-        
+
+        sorted_items = sorted(meshes_by_slot.items(), key=lambda x: x[1]["mat_id"])
+
         for name, data in sorted_items:
-            mesh_list = data['meshes']
-            mat_id = data['mat_id']
-            
+            mesh_list = data["meshes"]
+            mat_id = data["mat_id"]
             if not mesh_list:
                 continue
-            
+
             print(f"[VECTOR] Merging {len(mesh_list)} parts for {name}...")
-            if len(mesh_list) > 1:
-                combined_mesh = trimesh.util.concatenate(mesh_list)
-            else:
-                combined_mesh = mesh_list[0]
-            
-            self._fix_coordinates(combined_mesh, svg_height_mm)
-            
-            # 应用正确的预览颜色
-            # 使用 .get 防止越界，默认白色
+            combined = (
+                trimesh.util.concatenate(mesh_list) if len(mesh_list) > 1 else mesh_list[0]
+            )
+            self._fix_coordinates(combined, svg_height_mm)
+
             color_val = preview_colors.get(mat_id, [255, 255, 255, 255])
-            combined_mesh.visual.face_colors = color_val
-            
-            # Set metadata names (Critical for Slicer recognition)
-            combined_mesh.metadata['name'] = name
-            
-            # Use name as node name
-            scene.add_geometry(combined_mesh, geom_name=name)
-        
-        print(f"[VECTOR] ✅ Scene complete: {len(scene.geometry)} objects")
+            combined.visual.face_colors = color_val
+            combined.metadata["name"] = name
+            scene.add_geometry(combined, geom_name=name)
+
+        stage_timings["assemble_s"] = time.perf_counter() - t0
+        stage_timings["total_s"] = time.perf_counter() - t_total_start
+        stage_timings["extrude_cache_entries"] = len(extrude_cache)
+        self.last_stage_timings = stage_timings
+
+        print(
+            "[VECTOR] Stage timings (s): "
+            f"parse={stage_timings['parse_s']:.3f}, "
+            f"clip={stage_timings['occlusion_s']:.3f}, "
+            f"match={stage_timings['color_match_s']:.3f}, "
+            f"extrude_bottom={stage_timings['extrude_bottom_s']:.3f}, "
+            f"backing={stage_timings['backing_s']:.3f}, "
+            f"extrude_top={stage_timings['extrude_top_s']:.3f}, "
+            f"assemble={stage_timings['assemble_s']:.3f}, "
+            f"total={stage_timings['total_s']:.3f}"
+        )
+        print(f"[VECTOR] Extrude cache entries: {stage_timings['extrude_cache_entries']}")
+        print(f"[VECTOR] Scene complete: {len(scene.geometry)} objects")
         return scene
-    
-    def _parse_svg(self, svg_path: str, target_width_mm: float):
+
+    # ── Stage 2: Occlusion clipping (Chroma-style) ───────────────────────
+
+    @staticmethod
+    def _clip_occlusion(shape_data, return_silhouette=False):
+        """Clip shapes so no two overlap in XY.
+
+        Iterates in reverse draw order (topmost first).  Each shape is
+        subtracted from the accumulated union so that lower shapes only
+        retain geometry not already covered by higher shapes.
+
+        This mirrors ``ChromaPrint3D::detail::ClipOcclusion``.
         """
-        Parse SVG and normalize coordinates using Shapely Affinity.
-        
-        [Method]: Global Geometry Normalization
+        n = len(shape_data)
+        if n == 0:
+            return ([], None) if return_silhouette else []
+
+        result = []
+        accumulated = None
+        accum_bounds = None
+
+        for i in range(n - 1, -1, -1):
+            item = shape_data[i]
+            geom = item["poly"]
+
+            if geom is None or geom.is_empty:
+                continue
+
+            if accumulated is None:
+                clipped = geom
+            else:
+                if accum_bounds is None:
+                    accum_bounds = accumulated.bounds
+                geom_bounds = geom.bounds
+                intersects = not (
+                    geom_bounds[2] < accum_bounds[0] or
+                    geom_bounds[0] > accum_bounds[2] or
+                    geom_bounds[3] < accum_bounds[1] or
+                    geom_bounds[1] > accum_bounds[3]
+                )
+                if not intersects:
+                    clipped = geom
+                else:
+                    try:
+                        clipped = geom.difference(accumulated)
+                    except Exception:
+                        clipped = geom
+
+            if clipped is not None and not clipped.is_empty:
+                if not clipped.is_valid:
+                    clipped = clipped.buffer(0)
+                if not clipped.is_empty:
+                    result.append({
+                        "geometry": clipped,
+                        "color": item["color"],
+                        "draw_order": i,
+                    })
+
+            try:
+                if accumulated is None:
+                    accumulated = geom
+                    accum_bounds = geom.bounds
+                else:
+                    accumulated = accumulated.union(geom)
+                    gb = geom.bounds
+                    accum_bounds = (
+                        min(accum_bounds[0], gb[0]),
+                        min(accum_bounds[1], gb[1]),
+                        max(accum_bounds[2], gb[2]),
+                        max(accum_bounds[3], gb[3]),
+                    )
+            except Exception:
+                pass
+
+        result.reverse()
+        if return_silhouette:
+            return result, accumulated
+        return result
+
+    # ── Stage 4: Color matching with per-color cache ─────────────────────
+
+    def _match_colors(self, clipped_shapes, replacement_manager, num_channels):
+        """Match each shape's fill colour to a LUT recipe.
+
+        Identical fill colours share a single KDTree lookup via a cache,
+        mirroring ``ChromaPrint3D::VectorRecipeMap::Match`` behaviour.
+
+        Returns a list of dicts: ``{geometry, recipe, color}``.
+        """
+        color_cache = {}
+        matched = []
+
+        for item in clipped_shapes:
+            rgb = item["color"]
+
+            if rgb in color_cache:
+                recipe = color_cache[rgb]
+            else:
+                query_lab = self.img_processor._rgb_to_lab(np.array([rgb], dtype=np.uint8))
+                _, index = self.img_processor.kdtree.query(query_lab)
+                lut_idx = index[0]
+
+                if replacement_manager is not None:
+                    matched_rgb = tuple(int(c) for c in self.img_processor.lut_rgb[lut_idx])
+                    replacement = replacement_manager.get_replacement(matched_rgb)
+                    if replacement is not None:
+                        rep_lab = self.img_processor._rgb_to_lab(
+                            np.array([replacement], dtype=np.uint8)
+                        )
+                        _, rep_index = self.img_processor.kdtree.query(rep_lab)
+                        lut_idx = rep_index[0]
+
+                stack = self.img_processor.ref_stacks[lut_idx]
+                recipe = [
+                    min(int(stack[z]), num_channels - 1)
+                    for z in range(min(PrinterConfig.COLOR_LAYERS, len(stack)))
+                ]
+                color_cache[rgb] = recipe
+
+                hex_c = f"#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}"
+                print(f"  {hex_c} -> recipe {recipe}")
+
+            matched.append({
+                "geometry": item["geometry"],
+                "recipe": recipe,
+                "color": rgb,
+            })
+
+        return matched
+
+    # ── Stage 5: Run-length extrusion ────────────────────────────────────
+
+    @staticmethod
+    def _build_channel_runs(recipe, layers_to_use, num_channels):
+        """Build contiguous layer runs grouped by channel.
+
+        Returns:
+            dict[channel_id] -> list of (start_layer, end_layer)
+        """
+        runs_by_channel = {}
+        if layers_to_use <= 0:
+            return runs_by_channel
+
+        run_start = 0
+        run_channel = int(recipe[0])
+        for z in range(1, layers_to_use + 1):
+            current_channel = int(recipe[z]) if z < layers_to_use else None
+            if current_channel != run_channel:
+                if 0 <= run_channel < num_channels:
+                    runs_by_channel.setdefault(run_channel, []).append((run_start, z - 1))
+                run_start = z
+                run_channel = current_channel
+
+        return runs_by_channel
+
+    @staticmethod
+    def _run_length_extrude(matched_shapes, num_layers, layer_h,
+                            num_channels, slot_names, scale_factor, extrude_cache=None):
+        """Extrude each shape per channel, merging consecutive same-channel
+        layers into single volumes (run-length encoding).
+
+        Mirrors ``ChromaPrint3D::BuildVectorMeshes`` run-merging logic.
+        """
+        meshes_by_slot = {}
+
+        for item in matched_shapes:
+            geom = item["geometry"]
+            recipe = item["recipe"]
+            if geom is None or geom.is_empty:
+                continue
+
+            layers_to_use = min(num_layers, len(recipe))
+
+            runs_by_channel = VectorProcessor._build_channel_runs(
+                recipe, layers_to_use, num_channels
+            )
+            for ch, runs in runs_by_channel.items():
+                if ch >= len(slot_names):
+                    continue
+
+                slot_name = slot_names[ch]
+                if slot_name not in meshes_by_slot:
+                    meshes_by_slot[slot_name] = {"meshes": [], "mat_id": ch}
+
+                for run_start, run_end in runs:
+                    z_bot = run_start * layer_h
+                    height = (run_end - run_start + 1) * layer_h
+                    new_meshes = VectorProcessor._extrude_geometry(
+                        geom, height=height, z_offset=z_bot, scale=scale_factor,
+                        extrude_cache=extrude_cache,
+                    )
+                    meshes_by_slot[slot_name]["meshes"].extend(new_meshes)
+
+        return meshes_by_slot
+
+    # ── Stage 7: Double-sided helper ─────────────────────────────────────
+
+    @staticmethod
+    def _add_double_sided_layers(matched_shapes, num_layers, layer_h,
+                                  num_channels, slot_names, scale_factor,
+                                  top_z_start, meshes_by_slot, extrude_cache=None):
+        """Mirror colour layers above the backing for double-sided mode.
+
+        Layer Z order is inverted so the viewing surface faces upward on
+        the top side.
+        """
+        for item in matched_shapes:
+            geom = item["geometry"]
+            recipe = item["recipe"]
+            if geom is None or geom.is_empty:
+                continue
+
+            layers_to_use = min(num_layers, len(recipe))
+
+            runs_by_channel = VectorProcessor._build_channel_runs(
+                recipe, layers_to_use, num_channels
+            )
+            for ch, runs in runs_by_channel.items():
+                if ch >= len(slot_names):
+                    continue
+
+                slot_name = slot_names[ch]
+                if slot_name not in meshes_by_slot:
+                    meshes_by_slot[slot_name] = {"meshes": [], "mat_id": ch}
+
+                for run_start, run_end in runs:
+                    inv_start = (num_layers - 1) - run_end
+                    inv_end = (num_layers - 1) - run_start
+
+                    z_bot = top_z_start + inv_start * layer_h
+                    height = (inv_end - inv_start + 1) * layer_h
+                    new_meshes = VectorProcessor._extrude_geometry(
+                        geom, height=height, z_offset=z_bot, scale=scale_factor,
+                        extrude_cache=extrude_cache,
+                    )
+                    meshes_by_slot[slot_name]["meshes"].extend(new_meshes)
+
+    # ── SVG parsing ──────────────────────────────────────────────────────
+
+    def _parse_svg(self, svg_path: str, target_width_mm: float):
+        """Parse SVG and return shapes in draw order with normalised coords.
+
+        Returns:
+            ``(shape_list, scale_factor, bbox_tuple)``
+            where each shape item is ``{'poly': Polygon, 'color': (r,g,b)}``.
         """
         try:
             svg = SVG.parse(svg_path)
         except Exception as e:
             raise ValueError(f"Failed to parse SVG: {e}")
-        
+
         raw_shapes = []
-        
-        print(f"[VECTOR] Parsing SVG geometry...")
-        
-        # --- 阶段 1: 提取所有原始几何体 (不关心坐标) ---
+        print("[VECTOR] Parsing SVG geometry...")
+
         for element in svg.elements():
             if not isinstance(element, (Path, Shape)):
                 continue
-            
             if element.fill is None or element.fill.value is None:
                 continue
-            
+
             rgb = (element.fill.red, element.fill.green, element.fill.blue)
-            
-            # 统一转为 Path
+
             if isinstance(element, Shape) and not isinstance(element, Path):
                 try:
                     element = Path(element)
                 except Exception:
                     continue
-            
+
             try:
-                # 采样点生成多边形
-                # 这里我们先用一个相对安全的采样步长，后续不需重采，直接变换几何体
                 path_len = element.length()
                 if path_len == 0:
                     continue
-                
-                # 初始采样 (保证基本形状)
-                step = 1.0  # 初始像素步长
-                num_points = max(10, min(int(path_len / step), 2000))
-                
+
+                # Adaptive sampling: coarser for larger precision settings.
+                sample_step_svg = max(0.5, min(4.0, self.sampling_precision * 20.0))
+                num_points = max(10, min(int(path_len / sample_step_svg), 1200))
                 t_vals = np.linspace(0, 1, num_points)
                 pts = [element.point(t) for t in t_vals]
-                
+
                 if len(pts) < 3:
                     continue
-                
+
                 poly = Polygon([(p.x, p.y) for p in pts])
-                
                 if not poly.is_valid:
                     poly = poly.buffer(0)
-                
+
                 if poly.is_valid and not poly.is_empty:
-                    raw_shapes.append({'poly': poly, 'color': rgb})
-                    
-            except Exception as e:
+                    raw_shapes.append({"poly": poly, "color": rgb})
+            except Exception:
                 continue
-        
+
         if not raw_shapes:
             raise ValueError("No valid shapes found in SVG")
-        
-        # --- 阶段 2: 计算全局物理边界 (Global BBox) ---
-        # 将所有形状视为一个整体，计算它的真实边界
-        all_polys = [item['poly'] for item in raw_shapes]
-        
-        # 使用 unary_union 可能较慢，我们直接用 bounds 列表计算
-        # 这样速度极快且不容易出错
+
+        # Global bounding box
         min_xs, min_ys, max_xs, max_ys = [], [], [], []
-        for p in all_polys:
-            minx, miny, maxx, maxy = p.bounds
-            min_xs.append(minx)
-            min_ys.append(miny)
-            max_xs.append(maxx)
-            max_ys.append(maxy)
-        
-        global_min_x = min(min_xs)
-        global_min_y = min(min_ys)
-        global_max_x = max(max_xs)
-        global_max_y = max(max_ys)
-        
-        real_w = global_max_x - global_min_x
-        real_h = global_max_y - global_min_y
-        
-        print(f"[VECTOR] Global Geometry Bounds: x={global_min_x:.1f}, y={global_min_y:.1f}, w={real_w:.1f}, h={real_h:.1f}")
-        
+        for item in raw_shapes:
+            bx0, by0, bx1, by1 = item["poly"].bounds
+            min_xs.append(bx0)
+            min_ys.append(by0)
+            max_xs.append(bx1)
+            max_ys.append(by1)
+
+        gx0, gy0 = min(min_xs), min(min_ys)
+        real_w = max(max_xs) - gx0
+        real_h = max(max_ys) - gy0
+
+        print(f"[VECTOR] Global bounds: x={gx0:.1f}, y={gy0:.1f}, w={real_w:.1f}, h={real_h:.1f}")
         if real_w == 0:
             raise ValueError("Invalid geometry width (0)")
-        
-        # --- 阶段 3: 计算缩放与归位 ---
+
         scale_factor = target_width_mm / real_w
-        
+        simplify_tol_svg = max(0.0, (self.sampling_precision / max(scale_factor, 1e-9)) * 0.5)
+        min_area_svg = max(0.0, (self.sampling_precision ** 2) / max(scale_factor ** 2, 1e-12) * 0.25)
+
         final_shapes = []
-        
-        # --- 阶段 4: 整体平移 (Shapely Affinity) ---
-        # 直接操作几何对象，不操作点，这更稳健
         for item in raw_shapes:
-            original_poly = item['poly']
-            
-            # 平移：所有形状减去 global_min_x/y，使其左上角归零
-            shifted_poly = affinity.translate(original_poly, xoff=-global_min_x, yoff=-global_min_y)
-            
-            final_shapes.append({'poly': shifted_poly, 'color': item['color']})
-        
-        return final_shapes, scale_factor, (global_min_x, global_min_y, real_w, real_h)
-    
-    def _group_by_layers(self, shape_data, replacement_manager=None):
-        """
-        Group shapes by Z-layer and material ID.
-        
-        Each shape's color is matched to a 5-layer material stack.
-        The shape is then distributed to the appropriate layers.
-        
-        Args:
-            shape_data: List of {'poly': Polygon, 'color': (r,g,b)}
-            
-        Returns:
-            dict: {z_layer: {mat_id: [polygons]}}
-                Example: {0: {0: [poly1, poly2], 1: [poly3]}, 1: {...}}
-        """
-        layers = {}
-        
-        for item in shape_data:
-            r, g, b = item['color']
-            
-            # Query KD-Tree for nearest LUT color (in CIELAB space)
-            query_lab = self.img_processor._rgb_to_lab(np.array([[r, g, b]], dtype=np.uint8))
-            _, index = self.img_processor.kdtree.query(query_lab)
+            shifted = affinity.translate(item["poly"], xoff=-gx0, yoff=-gy0)
+            if simplify_tol_svg > 0.0:
+                try:
+                    shifted = shifted.simplify(simplify_tol_svg, preserve_topology=True)
+                except Exception:
+                    pass
 
-            # Get matched LUT color (for replacement lookup)
-            matched_rgb = tuple(int(c) for c in self.img_processor.lut_rgb[index][0])
+            if not shifted.is_valid:
+                shifted = shifted.buffer(0)
 
-            # Apply replacement if provided (replacement keys are LUT colors)
-            if replacement_manager is not None:
-                replacement = replacement_manager.get_replacement(matched_rgb)
-                if replacement is not None:
-                    rep_lab = self.img_processor._rgb_to_lab(np.array([replacement], dtype=np.uint8))
-                    _, rep_index = self.img_processor.kdtree.query(rep_lab)
-                    index = rep_index
+            if shifted.is_empty or shifted.area <= min_area_svg:
+                continue
+            final_shapes.append({"poly": shifted, "color": item["color"]})
 
-            # Get 5-layer material stack
-            stack = self.img_processor.ref_stacks[index][0]
-            
-            # Distribute polygon to layers
-            for z, mat_id in enumerate(stack):
-                if z >= 5:  # Only use first 5 layers
-                    break
-                
-                # Initialize nested dicts
-                if z not in layers:
-                    layers[z] = {}
-                if mat_id not in layers[z]:
-                    layers[z][mat_id] = []
-                
-                # Add polygon to this layer/material
-                layers[z][mat_id].append(item['poly'])
-        
-        return layers
-    
-    def _perform_boolean_union(self, polygons):
-        """
-        Merge overlapping polygons using boolean union.
-        
-        This is equivalent to Clipper's union operation but uses
-        Shapely's Python-native implementation.
-        
-        Args:
-            polygons: List of Shapely Polygon objects
-            
-        Returns:
-            Geometry: Merged result (Polygon or MultiPolygon)
-        """
-        if not polygons:
-            return None
-        
-        return unary_union(polygons)
-    
-    def _extrude_geometry(self, geometry, height, z_offset, scale):
-        """
-        Extrude 2D geometry to 3D meshes.
-        
-        Handles both single Polygon and MultiPolygon geometries.
-        
-        Args:
-            geometry: Shapely Polygon or MultiPolygon
-            height: Extrusion height in mm
-            z_offset: Z position of bottom face
-            scale: Scale factor (SVG units to mm)
-            
-        Returns:
-            list: List of trimesh.Trimesh objects
-        """
+        return final_shapes, scale_factor, (gx0, gy0, real_w, real_h)
+
+    # ── Geometry helpers ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _extrude_geometry(geometry, height, z_offset, scale, extrude_cache=None):
+        """Extrude 2D Shapely geometry to 3D trimesh objects."""
         meshes = []
-        
         if geometry is None or geometry.is_empty:
             return meshes
-        
-        # Handle both Polygon and MultiPolygon
-        polys = geometry.geoms if hasattr(geometry, 'geoms') else [geometry]
-        
+
+        polys = geometry.geoms if hasattr(geometry, "geoms") else [geometry]
+
         for poly in polys:
             if poly.is_empty:
                 continue
-            
+            if not hasattr(poly, "exterior"):
+                continue
             try:
-                # Extrude polygon to 3D
-                m = trimesh.creation.extrude_polygon(poly, height=height)
-                
-                # Apply scale (SVG units → mm)
-                m.apply_scale([scale, scale, 1])
-                
-                # Apply Z translation
+                cache_key = None
+                cached_base = None
+                if extrude_cache is not None:
+                    cache_key = (poly.wkb, round(float(height), 6), round(float(scale), 8))
+                    cached_base = extrude_cache.get(cache_key)
+
+                if cached_base is None:
+                    m_base = trimesh.creation.extrude_polygon(poly, height=height)
+                    m_base.apply_scale([scale, scale, 1])
+                    if extrude_cache is not None and cache_key is not None:
+                        extrude_cache[cache_key] = m_base.copy()
+                else:
+                    m_base = cached_base
+
+                m = m_base.copy()
                 m.apply_translation([0, 0, z_offset])
-                
                 meshes.append(m)
-                
             except Exception as e:
                 print(f"[VECTOR] Warning: Failed to extrude polygon: {e}")
                 continue
-        
+
         return meshes
-    
-    def _fix_coordinates(self, mesh, svg_height_mm):
-        """
-        Fix SVG coordinate system (Y-down) to 3D printer (Y-up).
-        
-        SVG uses Y-down coordinate system, but 3D printers use Y-up.
-        This method flips the Y-axis and translates back to positive quadrant.
-        
-        Args:
-            mesh: trimesh.Trimesh object (modified in-place)
-            svg_height_mm: SVG height in millimeters
-        """
-        # Flip Y-axis
+
+    @staticmethod
+    def _fix_coordinates(mesh, svg_height_mm):
+        """Flip Y-axis from SVG (Y-down) to printer (Y-up) coordinate system."""
         transform = np.eye(4)
         transform[1, 1] = -1
         mesh.apply_transform(transform)
-        
-        # Translate back to positive quadrant
-        # (Flipping around 0 makes everything negative)
         mesh.apply_translation([0, svg_height_mm, 0])

--- a/main.py
+++ b/main.py
@@ -40,15 +40,19 @@ import threading
 import webbrowser
 import socket
 import gradio as gr     # type:ignore
+from config import get_tray_runtime_policy
 from ui.layout_new import create_app
 from ui.styles import CUSTOM_CSS
 
-HAS_DISPLAY = os.environ.get("DISPLAY") or os.name == "nt"
-if HAS_DISPLAY:
+ENABLE_TRAY, TRAY_POLICY_REASON = get_tray_runtime_policy()
+LuminaTray = None
+if ENABLE_TRAY:
     try:
         from core.tray import LuminaTray
-    except ImportError:
-        HAS_DISPLAY = False
+    except Exception as e:
+        print(f"⚠️ Warning: Tray module unavailable, disabling tray: {e}")
+        ENABLE_TRAY = False
+        TRAY_POLICY_REASON = f"Tray module unavailable: {e}"
         
 def find_available_port(start_port=7860, max_attempts=1000):
     """Return first free port in [start_port, start_port + max_attempts)."""
@@ -68,11 +72,15 @@ def start_browser(port):
 if __name__ == "__main__":
     try:
         tray = None
-        try:
-            PORT = find_available_port(7860)
-            tray = LuminaTray(port=PORT)
-        except Exception as e:
-            print(f"⚠️ Warning: Failed to initialize tray: {e}")
+        PORT = find_available_port(7860)
+
+        if ENABLE_TRAY and LuminaTray is not None:
+            try:
+                tray = LuminaTray(port=PORT)
+            except Exception as e:
+                print(f"⚠️ Warning: Failed to initialize tray: {e}")
+        else:
+            print(f"[TRAY] {TRAY_POLICY_REASON}")
 
         threading.Thread(target=start_browser, args=(PORT,), daemon=True).start()
         print(f"✨ Lumina Studio is running on http://127.0.0.1:{PORT}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ colormath
 # Native Vector Engine dependencies
 svgelements>=1.9.0
 shapely>=2.0.0
+mapbox-earcut

--- a/tests/test_converter_vector_export_unit.py
+++ b/tests/test_converter_vector_export_unit.py
@@ -1,0 +1,190 @@
+"""Unit tests for the vector branch export in converter.py.
+
+Validates that:
+    1. The vector branch calls export_scene_with_bambu_metadata (not scene.export).
+    2. The slot_names passed to the exporter match the scene's geometry keys.
+"""
+
+import sys
+import os
+import types
+from unittest.mock import patch, MagicMock
+
+# Stub heavy third-party modules that core.__init__ transitively imports
+# so we can test the converter without installing them in CI.
+for _mod_name in ("gradio", "gradio.themes"):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+import pytest
+import trimesh
+import numpy as np
+from utils.bambu_3mf_writer import export_scene_with_bambu_metadata, BambuStudio3MFWriter
+
+
+def _build_fake_processor(scene):
+    """Return a MagicMock that behaves like VectorProcessor."""
+    vp = MagicMock()
+    vp.svg_to_mesh.return_value = scene
+    vp.img_processor.lut_rgb = np.zeros((256, 3))
+    vp.img_processor._load_svg.return_value = np.zeros((100, 100, 4), dtype=np.uint8)
+    return vp
+
+
+# =====================================================================
+# 1. Vector branch uses Bambu metadata export
+# =====================================================================
+
+class TestVectorBranchExport:
+    """Confirm the vector conversion path goes through the unified
+    Bambu metadata exporter rather than the plain trimesh export."""
+
+    @patch("core.converter.export_scene_with_bambu_metadata")
+    @patch("core.vector_engine.VectorProcessor")
+    def test_bambu_export_called(self, MockVP, mock_bambu_export, tmp_path):
+        """export_scene_with_bambu_metadata should be invoked for SVG vector mode."""
+        from config import ModelingMode
+
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+            '<rect x="0" y="0" width="100" height="100" fill="#ff0000"/>'
+            '</svg>'
+        )
+
+        fake_scene = trimesh.Scene()
+        mesh = trimesh.creation.box(extents=[10, 10, 1])
+        mesh.metadata["name"] = "White"
+        mesh.visual.face_colors = [255, 255, 255, 255]
+        fake_scene.add_geometry(mesh, geom_name="White")
+
+        MockVP.return_value = _build_fake_processor(fake_scene)
+
+        from core.converter import convert_image_to_3d
+
+        dummy_lut = str(tmp_path / "dummy.npy")
+        np.save(dummy_lut, np.zeros(10))
+
+        convert_image_to_3d(
+            image_path=str(svg_file),
+            lut_path=dummy_lut,
+            target_width_mm=50.0,
+            spacer_thick=1.6,
+            structure_mode="Single-sided",
+            auto_bg=False,
+            bg_tol=30,
+            color_mode="4-Color",
+            add_loop=False,
+            loop_width=5, loop_length=20, loop_hole=3, loop_pos="Top",
+            modeling_mode=ModelingMode.VECTOR,
+        )
+
+        mock_bambu_export.assert_called_once()
+
+    @patch("core.converter.export_scene_with_bambu_metadata")
+    @patch("core.vector_engine.VectorProcessor")
+    def test_slot_names_match_scene_geometry(self, MockVP, mock_bambu_export, tmp_path):
+        """slot_names passed to exporter should equal list(scene.geometry.keys())."""
+        from config import ModelingMode
+
+        svg_file = tmp_path / "test2.svg"
+        svg_file.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">'
+            '<circle cx="25" cy="25" r="20" fill="#0000ff"/>'
+            '</svg>'
+        )
+
+        fake_scene = trimesh.Scene()
+        for name in ["White", "Cyan", "Board"]:
+            m = trimesh.creation.box(extents=[5, 5, 0.5])
+            m.metadata["name"] = name
+            fake_scene.add_geometry(m, geom_name=name)
+
+        MockVP.return_value = _build_fake_processor(fake_scene)
+
+        from core.converter import convert_image_to_3d
+
+        dummy_lut = str(tmp_path / "dummy2.npy")
+        np.save(dummy_lut, np.zeros(10))
+
+        convert_image_to_3d(
+            image_path=str(svg_file),
+            lut_path=dummy_lut,
+            target_width_mm=30.0,
+            spacer_thick=1.6,
+            structure_mode="Single-sided",
+            auto_bg=False,
+            bg_tol=30,
+            color_mode="4-Color",
+            add_loop=False,
+            loop_width=5, loop_length=20, loop_hole=3, loop_pos="Top",
+            modeling_mode=ModelingMode.VECTOR,
+        )
+
+        _, kwargs = mock_bambu_export.call_args
+        assert kwargs["slot_names"] == ["White", "Cyan", "Board"]
+
+    @patch("core.converter.export_scene_with_bambu_metadata")
+    @patch("core.vector_engine.VectorProcessor")
+    def test_empty_scene_returns_error(self, MockVP, mock_bambu_export, tmp_path):
+        """Empty vector scene should fail before exporter is called."""
+        from config import ModelingMode
+
+        svg_file = tmp_path / "empty.svg"
+        svg_file.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            '<rect x="0" y="0" width="10" height="10" fill="#ffffff"/>'
+            '</svg>'
+        )
+
+        empty_scene = trimesh.Scene()
+        MockVP.return_value = _build_fake_processor(empty_scene)
+
+        from core.converter import convert_image_to_3d
+
+        dummy_lut = str(tmp_path / "dummy3.npy")
+        np.save(dummy_lut, np.zeros(10))
+
+        out_path, glb_path, preview_img, msg = convert_image_to_3d(
+            image_path=str(svg_file),
+            lut_path=dummy_lut,
+            target_width_mm=20.0,
+            spacer_thick=1.6,
+            structure_mode="Single-sided",
+            auto_bg=False,
+            bg_tol=30,
+            color_mode="4-Color",
+            add_loop=False,
+            loop_width=5, loop_length=20, loop_hole=3, loop_pos="Top",
+            modeling_mode=ModelingMode.VECTOR,
+        )
+
+        assert out_path is None
+        assert glb_path is None
+        assert preview_img is None
+        assert "no valid geometry" in msg.lower()
+        mock_bambu_export.assert_not_called()
+
+
+class TestBambuExportGuardrails:
+
+    def test_export_scene_raises_on_missing_slot_geometry(self, tmp_path):
+        scene = trimesh.Scene()
+        scene.add_geometry(trimesh.creation.box(extents=[5, 5, 1]), geom_name="White")
+
+        out_path = tmp_path / "out.3mf"
+        with pytest.raises(ValueError, match="Missing geometries"):
+            export_scene_with_bambu_metadata(
+                scene=scene,
+                output_path=str(out_path),
+                slot_names=["White", "Cyan"],
+                preview_colors={0: [255, 255, 255, 255], 1: [0, 134, 214, 255]},
+                settings={},
+                color_mode="4-Color",
+            )
+
+    def test_writer_add_mesh_rejects_empty_mesh(self, tmp_path):
+        writer = BambuStudio3MFWriter(str(tmp_path / "x.3mf"), settings={}, color_mode="4-Color")
+        empty = trimesh.Trimesh(vertices=np.zeros((0, 3)), faces=np.zeros((0, 3), dtype=np.int64))
+        with pytest.raises(ValueError, match="empty geometry"):
+            writer.add_mesh(empty, "White", (255, 255, 255))

--- a/tests/test_preview_click_selection_unit.py
+++ b/tests/test_preview_click_selection_unit.py
@@ -1,0 +1,44 @@
+"""Unit tests for preview-click selection safety and HTML rendering."""
+
+import sys
+from unittest.mock import MagicMock
+
+# Stub gradio for environments where full UI dependencies are unavailable.
+for _mod_name in ("gradio", "gradio.themes"):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from core.converter import _resolve_click_selection_hexes, on_preview_click_select_color
+from ui.palette_extension import build_selected_dual_color_html
+
+
+class _EvtNoneIndex:
+    index = None
+
+
+def test_invalid_click_returns_none_hex():
+    """Invalid click events should not return dict-like hex values."""
+    cache = {"bed_label": "256x256 mm"}
+    _img, _text, hex_val, msg = on_preview_click_select_color(cache, _EvtNoneIndex())
+    assert hex_val is None
+    assert "无效点击" in msg
+
+
+def test_resolve_click_selection_hexes_rejects_non_string_default():
+    """dict default_hex (e.g. gr.update payload) should be normalized away."""
+    display_hex, state_hex = _resolve_click_selection_hexes({}, {"value": "bad"})
+    assert display_hex is None
+    assert state_hex is None
+
+
+def test_resolve_click_selection_hexes_prefers_cached_strings():
+    cache = {"selected_quantized_hex": "#112233", "selected_matched_hex": "#445566"}
+    display_hex, state_hex = _resolve_click_selection_hexes(cache, {"value": "bad"})
+    assert display_hex == "#445566"
+    assert state_hex == "#112233"
+
+
+def test_selected_dual_color_html_accepts_non_string_inputs():
+    """HTML renderer should gracefully fallback to #000000 for bad input types."""
+    html = build_selected_dual_color_html({"x": 1}, None, lang="zh")
+    assert "#000000" in html

--- a/tests/test_vector_engine_unit.py
+++ b/tests/test_vector_engine_unit.py
@@ -1,0 +1,297 @@
+"""Unit tests for the Chroma-aligned vector engine (core/vector_engine.py).
+
+Covers:
+    1. Occlusion clipping: reverse-order accumulative difference
+    2. Run-length extrusion: consecutive same-channel layers merged
+    3. Output ordering: meshes_by_slot sorted by material ID
+"""
+
+import sys
+import os
+import types
+import importlib.util
+from unittest.mock import patch
+
+import pytest
+from shapely.geometry import Polygon, box
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _ROOT)
+
+from config import PrinterConfig
+
+# Load core.vector_engine directly from its file to avoid the heavy
+# core.__init__ import chain (which pulls in gradio, etc.).
+_spec = importlib.util.spec_from_file_location(
+    "core.vector_engine", os.path.join(_ROOT, "core", "vector_engine.py")
+)
+_ve = importlib.util.module_from_spec(_spec)
+# Provide a minimal 'core' parent package so relative imports resolve
+if "core" not in sys.modules:
+    _pkg = types.ModuleType("core")
+    _pkg.__path__ = [os.path.join(_ROOT, "core")]
+    sys.modules["core"] = _pkg
+sys.modules["core.vector_engine"] = _ve
+_spec.loader.exec_module(_ve)
+VectorProcessor = _ve.VectorProcessor
+
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+def _rect(x0, y0, x1, y1, color=(255, 0, 0)):
+    """Create a shape_data dict compatible with _clip_occlusion input."""
+    return {"poly": box(x0, y0, x1, y1), "color": color}
+
+
+# =====================================================================
+# 1. Occlusion clipping
+# =====================================================================
+
+class TestClipOcclusion:
+    """Verify ChromaPrint3D-style reverse-order occlusion clipping."""
+
+    def test_no_overlap_preserves_all(self):
+        """Non-overlapping shapes should pass through unchanged."""
+        shapes = [
+            _rect(0, 0, 10, 10, color=(255, 0, 0)),
+            _rect(20, 0, 30, 10, color=(0, 255, 0)),
+        ]
+        result = VectorProcessor._clip_occlusion(shapes)
+        assert len(result) == 2
+        for r in result:
+            assert not r["geometry"].is_empty
+
+    def test_later_shape_covers_earlier(self):
+        """Later shape fully covering earlier → earlier completely removed."""
+        shapes = [
+            _rect(0, 0, 10, 10, color=(255, 0, 0)),   # bottom (draw order 0)
+            _rect(0, 0, 10, 10, color=(0, 255, 0)),    # top    (draw order 1)
+        ]
+        result = VectorProcessor._clip_occlusion(shapes)
+        top = [r for r in result if r["color"] == (0, 255, 0)]
+        bottom = [r for r in result if r["color"] == (255, 0, 0)]
+        assert len(top) == 1
+        assert not top[0]["geometry"].is_empty
+        assert len(bottom) == 0  # fully occluded
+
+    def test_partial_overlap(self):
+        """Partial overlap: earlier shape trimmed, later shape full."""
+        shapes = [
+            _rect(0, 0, 20, 10, color=(255, 0, 0)),  # bottom, wider
+            _rect(5, 0, 15, 10, color=(0, 255, 0)),   # top, narrower overlap
+        ]
+        result = VectorProcessor._clip_occlusion(shapes)
+
+        top = [r for r in result if r["color"] == (0, 255, 0)]
+        bottom = [r for r in result if r["color"] == (255, 0, 0)]
+
+        assert len(top) == 1
+        assert len(bottom) == 1
+
+        # Top shape should be fully preserved
+        assert abs(top[0]["geometry"].area - 100.0) < 1e-6
+
+        # Bottom shape should be trimmed: original 200 minus overlap 100
+        assert abs(bottom[0]["geometry"].area - 100.0) < 1.0
+
+    def test_draw_order_preserved(self):
+        """Result list should be in original draw order (bottom → top)."""
+        shapes = [
+            _rect(0, 0, 10, 10, color=(1, 0, 0)),
+            _rect(5, 0, 15, 10, color=(0, 1, 0)),
+            _rect(10, 0, 20, 10, color=(0, 0, 1)),
+        ]
+        result = VectorProcessor._clip_occlusion(shapes)
+        orders = [r["draw_order"] for r in result]
+        assert orders == sorted(orders), "draw_order should be monotonically increasing"
+
+    def test_empty_input(self):
+        result = VectorProcessor._clip_occlusion([])
+        assert result == []
+
+    def test_return_silhouette_when_requested(self):
+        """When requested, occlusion returns accumulated silhouette geometry."""
+        shapes = [
+            _rect(0, 0, 10, 10, color=(255, 0, 0)),
+            _rect(5, 0, 15, 10, color=(0, 255, 0)),
+        ]
+        result, silhouette = VectorProcessor._clip_occlusion(shapes, return_silhouette=True)
+        assert len(result) == 2
+        assert silhouette is not None
+        assert not silhouette.is_empty
+        # silhouette is union of both input rectangles: 100 + 100 - 50 overlap
+        assert abs(silhouette.area - 150.0) < 1e-6
+
+    def test_three_stacked_shapes(self):
+        """Three fully stacked shapes: only topmost survives."""
+        shapes = [
+            _rect(0, 0, 10, 10, color=(1, 0, 0)),
+            _rect(0, 0, 10, 10, color=(0, 1, 0)),
+            _rect(0, 0, 10, 10, color=(0, 0, 1)),
+        ]
+        result = VectorProcessor._clip_occlusion(shapes)
+        assert len(result) == 1
+        assert result[0]["color"] == (0, 0, 1)
+
+    def test_no_small_feature_exemption(self):
+        """Even tiny shapes are subject to occlusion — no special exemption."""
+        shapes = [
+            _rect(0, 0, 1, 1, color=(255, 0, 0)),     # tiny bottom
+            _rect(0, 0, 100, 100, color=(0, 255, 0)),  # large top covering it
+        ]
+        result = VectorProcessor._clip_occlusion(shapes)
+        reds = [r for r in result if r["color"] == (255, 0, 0)]
+        assert len(reds) == 0, "small feature should be fully occluded"
+
+
+# =====================================================================
+# 2. Run-length extrusion
+# =====================================================================
+
+class TestRunLengthExtrude:
+    """Verify consecutive same-channel layers are merged into single volumes."""
+
+    LAYER_H = PrinterConfig.LAYER_HEIGHT   # 0.08
+    SLOT_NAMES = ["White", "Cyan", "Magenta", "Yellow"]
+
+    def _make_matched(self, geometry, recipe):
+        return [{"geometry": geometry, "recipe": recipe, "color": (0, 0, 0)}]
+
+    def test_single_channel_all_layers(self):
+        """All 5 layers mapped to channel 1 → single run for channel 1."""
+        geom = box(0, 0, 10, 10)
+        matched = self._make_matched(geom, [1, 1, 1, 1, 1])
+
+        result = VectorProcessor._run_length_extrude(
+            matched, num_layers=5, layer_h=self.LAYER_H,
+            num_channels=4, slot_names=self.SLOT_NAMES, scale_factor=1.0,
+        )
+
+        assert "Cyan" in result
+        assert len(result["Cyan"]["meshes"]) == 1  # single merged volume
+
+    def test_alternating_channels_no_merge(self):
+        """Alternating recipe [0,1,0,1,0] → no channel gets consecutive layers."""
+        geom = box(0, 0, 10, 10)
+        matched = self._make_matched(geom, [0, 1, 0, 1, 0])
+
+        result = VectorProcessor._run_length_extrude(
+            matched, num_layers=5, layer_h=self.LAYER_H,
+            num_channels=4, slot_names=self.SLOT_NAMES, scale_factor=1.0,
+        )
+
+        white_count = len(result.get("White", {}).get("meshes", []))
+        cyan_count = len(result.get("Cyan", {}).get("meshes", []))
+        assert white_count == 3  # layers 0, 2, 4 → three separate runs
+        assert cyan_count == 2   # layers 1, 3 → two separate runs
+
+    def test_run_merges_consecutive(self):
+        """Recipe [2,2,2,0,0] → channel 2 gets one run (layers 0-2),
+        channel 0 gets one run (layers 3-4)."""
+        geom = box(0, 0, 10, 10)
+        matched = self._make_matched(geom, [2, 2, 2, 0, 0])
+
+        result = VectorProcessor._run_length_extrude(
+            matched, num_layers=5, layer_h=self.LAYER_H,
+            num_channels=4, slot_names=self.SLOT_NAMES, scale_factor=1.0,
+        )
+
+        assert len(result["Magenta"]["meshes"]) == 1
+        assert len(result["White"]["meshes"]) == 1
+
+    def test_material_id_in_result(self):
+        """Each slot entry should carry correct mat_id."""
+        geom = box(0, 0, 5, 5)
+        matched = self._make_matched(geom, [3, 3, 3, 3, 3])
+
+        result = VectorProcessor._run_length_extrude(
+            matched, num_layers=5, layer_h=self.LAYER_H,
+            num_channels=4, slot_names=self.SLOT_NAMES, scale_factor=1.0,
+        )
+
+        assert result["Yellow"]["mat_id"] == 3
+
+    def test_empty_geometry_skipped(self):
+        """Empty geometry should produce no meshes."""
+        geom = Polygon()
+        matched = self._make_matched(geom, [0, 0, 0, 0, 0])
+
+        result = VectorProcessor._run_length_extrude(
+            matched, num_layers=5, layer_h=self.LAYER_H,
+            num_channels=4, slot_names=self.SLOT_NAMES, scale_factor=1.0,
+        )
+
+        assert len(result) == 0
+
+
+# =====================================================================
+# 3. Output ordering
+# =====================================================================
+
+class TestOutputOrdering:
+    """Verify meshes_by_slot is sorted by material ID when assembling scene."""
+
+    def test_sorted_by_mat_id(self):
+        """Simulated meshes_by_slot should sort by mat_id."""
+        meshes_by_slot = {
+            "Yellow": {"meshes": ["m"], "mat_id": 3},
+            "White":  {"meshes": ["m"], "mat_id": 0},
+            "Cyan":   {"meshes": ["m"], "mat_id": 1},
+        }
+        sorted_items = sorted(meshes_by_slot.items(), key=lambda x: x[1]["mat_id"])
+        names = [name for name, _ in sorted_items]
+        assert names == ["White", "Cyan", "Yellow"]
+
+
+# =====================================================================
+# 4. Extrude geometry helper
+# =====================================================================
+
+class TestExtrudeGeometry:
+
+    def test_polygon_produces_mesh(self):
+        poly = box(0, 0, 10, 10)
+        meshes = VectorProcessor._extrude_geometry(poly, height=1.0, z_offset=0, scale=1.0)
+        assert len(meshes) == 1
+        assert meshes[0].vertices.shape[0] > 0
+
+    def test_multipolygon(self):
+        from shapely.ops import unary_union
+        mp = unary_union([box(0, 0, 5, 5), box(10, 0, 15, 5)])
+        meshes = VectorProcessor._extrude_geometry(mp, height=0.5, z_offset=0, scale=1.0)
+        assert len(meshes) == 2
+
+    def test_empty_returns_empty(self):
+        meshes = VectorProcessor._extrude_geometry(Polygon(), height=1.0, z_offset=0, scale=1.0)
+        assert meshes == []
+
+    def test_none_returns_empty(self):
+        meshes = VectorProcessor._extrude_geometry(None, height=1.0, z_offset=0, scale=1.0)
+        assert meshes == []
+
+    def test_extrude_cache_reuses_base_mesh(self):
+        """Same polygon/height/scale should hit cache and only extrude once."""
+        poly = box(0, 0, 10, 10)
+        cache = {}
+
+        call_count = {"n": 0}
+        real_box = _ve.trimesh.creation.box
+
+        def fake_extrude_polygon(_poly, height):
+            call_count["n"] += 1
+            # return any valid mesh; dimensions are irrelevant for cache count check
+            return real_box(extents=[1, 1, max(height, 1e-6)])
+
+        with patch.object(_ve.trimesh.creation, "extrude_polygon", side_effect=fake_extrude_polygon):
+            meshes1 = VectorProcessor._extrude_geometry(
+                poly, height=1.0, z_offset=0.0, scale=1.0, extrude_cache=cache
+            )
+            meshes2 = VectorProcessor._extrude_geometry(
+                poly, height=1.0, z_offset=2.0, scale=1.0, extrude_cache=cache
+            )
+
+        assert len(meshes1) == 1
+        assert len(meshes2) == 1
+        assert call_count["n"] == 1

--- a/ui/layout_new.py
+++ b/ui/layout_new.py
@@ -6,9 +6,11 @@ UI layout definition - Refactored version with language switching support
 
 import json
 import os
+import re
 import shutil
 import time
 import zipfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import gradio as gr
@@ -2648,22 +2650,72 @@ def create_converter_tab_content(lang: str, lang_state=None, theme_state=None) -
     # ========== Image Crop Extension Events (Non-invasive) ==========
     from core.image_preprocessor import ImagePreprocessor
     
+    def _parse_svg_dimensions(svg_path):
+        """Parse SVG width/height with viewBox fallback."""
+        try:
+            root = ET.parse(svg_path).getroot()
+        except Exception:
+            return 0, 0
+
+        def _parse_len(raw):
+            if not raw:
+                return None
+            m = re.search(r"([0-9]+(?:\.[0-9]+)?)", str(raw))
+            if not m:
+                return None
+            try:
+                return int(float(m.group(1)))
+            except Exception:
+                return None
+
+        w = _parse_len(root.get("width"))
+        h = _parse_len(root.get("height"))
+
+        if w and h and w > 0 and h > 0:
+            return w, h
+
+        view_box = root.get("viewBox") or root.get("viewbox")
+        if view_box:
+            try:
+                parts = [float(v) for v in re.split(r"[,\s]+", view_box.strip()) if v]
+                if len(parts) == 4:
+                    vb_w = int(abs(parts[2]))
+                    vb_h = int(abs(parts[3]))
+                    if vb_w > 0 and vb_h > 0:
+                        return vb_w, vb_h
+            except Exception:
+                pass
+
+        return 0, 0
+
     def on_image_upload_process_with_html(image_path):
         """When image is uploaded, process and prepare for crop modal (不分析颜色)"""
         if image_path is None:
             return (
                 0, 0, None,
-                '<div id="preprocess-dimensions-data" data-width="0" data-height="0" style="display:none;"></div>'
+                '<div id="preprocess-dimensions-data" data-width="0" data-height="0" data-is-svg="0" style="display:none;"></div>'
             )
         
         try:
+            # SVG: bypass PIL-based preprocessor to avoid "cannot identify image file" noise.
+            if isinstance(image_path, str) and image_path.lower().endswith(".svg"):
+                width, height = _parse_svg_dimensions(image_path)
+                dimensions_html = (
+                    f'<div id="preprocess-dimensions-data" data-width="{width}" '
+                    f'data-height="{height}" data-is-svg="1" style="display:none;"></div>'
+                )
+                return (width, height, image_path, dimensions_html)
+
             info = ImagePreprocessor.process_upload(image_path)
             # 不在这里分析颜色，等用户确认裁剪后再分析
-            dimensions_html = f'<div id="preprocess-dimensions-data" data-width="{info.width}" data-height="{info.height}" style="display:none;"></div>'
+            dimensions_html = (
+                f'<div id="preprocess-dimensions-data" data-width="{info.width}" '
+                f'data-height="{info.height}" data-is-svg="0" style="display:none;"></div>'
+            )
             return (info.width, info.height, info.processed_path, dimensions_html)
         except Exception as e:
             print(f"Image upload error: {e}")
-            return (0, 0, None, '<div id="preprocess-dimensions-data" data-width="0" data-height="0" style="display:none;"></div>')
+            return (0, 0, None, '<div id="preprocess-dimensions-data" data-width="0" data-height="0" data-is-svg="0" style="display:none;"></div>')
     
     # JavaScript to open crop modal (不传递颜色推荐，弹窗中不显示)
     # Check if crop modal is enabled before opening
@@ -2743,6 +2795,11 @@ def create_converter_tab_content(lang: str, lang_state=None, theme_state=None) -
             const dimElement = document.querySelector('#preprocess-dimensions-data');
             console.log('[CROP] dimElement found:', !!dimElement);
             if (dimElement) {
+                const isSvgUpload = dimElement.dataset.isSvg === '1';
+                if (isSvgUpload) {
+                    console.log('[CROP] SVG upload detected, skipping crop modal.');
+                    return;
+                }
                 const width = parseInt(dimElement.dataset.width) || 0;
                 const height = parseInt(dimElement.dataset.height) || 0;
                 console.log('[CROP] Dimensions:', width, 'x', height);
@@ -2785,6 +2842,8 @@ def create_converter_tab_content(lang: str, lang_state=None, theme_state=None) -
         if processed_path is None:
             return None
         try:
+            if isinstance(processed_path, str) and processed_path.lower().endswith(".svg"):
+                return processed_path
             result_path = ImagePreprocessor.convert_to_png(processed_path)
             return result_path
         except Exception as e:
@@ -2803,6 +2862,9 @@ def create_converter_tab_content(lang: str, lang_state=None, theme_state=None) -
         if processed_path is None:
             return None
         try:
+            if isinstance(processed_path, str) and processed_path.lower().endswith(".svg"):
+                print("[DEBUG] SVG uploaded, skipping raster crop and keeping original path")
+                return processed_path
             import json
             data = json.loads(crop_json) if crop_json else {"x": 0, "y": 0, "w": 100, "h": 100}
             x = int(data.get("x", 0))
@@ -2957,17 +3019,90 @@ def create_converter_tab_content(lang: str, lang_state=None, theme_state=None) -
         glb_path = generate_realtime_glb(cache) if cache is not None else None
         return _preview_update(display), cache, status, glb_path
 
-    # 像素模式下禁用孤立像素清理 Checkbox
-    def on_modeling_mode_change_cleanup(mode):
-        if mode == ModelingMode.PIXEL:
-            return gr.update(interactive=False, value=False, info="像素模式下不支持孤立像素清理 | Not available in Pixel Art mode")
+    # 建模模式切换：统一处理可用参数提示与禁用逻辑
+    def on_modeling_mode_change_controls(mode):
+        is_pixel = mode == ModelingMode.PIXEL
+        is_vector = mode == ModelingMode.VECTOR
+
+        # Cleanup: Pixel 模式禁用，其它模式可用
+        if is_pixel:
+            cleanup_update = gr.update(
+                interactive=False,
+                value=False,
+                info="像素模式下不支持孤立像素清理 | Not available in Pixel Art mode",
+            )
         else:
-            return gr.update(interactive=True, info="清理 LUT 匹配后的孤立像素，提升打印成功率")
+            cleanup_update = gr.update(
+                interactive=True,
+                info="清理 LUT 匹配后的孤立像素，提升打印成功率",
+            )
+
+        # Outline / Cloisonné: 当前仅在 Raster 路径生效，Vector 模式禁用并提示
+        if is_vector:
+            outline_checkbox_update = gr.update(
+                interactive=False,
+                value=False,
+                info="Vector(SVG) 模式暂不支持描边；该选项仅在 Raster 路径生效",
+            )
+            outline_width_update = gr.update(
+                interactive=False,
+                info="Vector(SVG) 模式下已禁用",
+            )
+            cloisonne_checkbox_update = gr.update(
+                interactive=False,
+                value=False,
+                info="Vector(SVG) 模式暂不支持掐丝珐琅；该选项仅在 Raster 路径生效",
+            )
+            wire_width_update = gr.update(
+                interactive=False,
+                info="Vector(SVG) 模式下已禁用",
+            )
+            wire_height_update = gr.update(
+                interactive=False,
+                info="Vector(SVG) 模式下已禁用",
+            )
+        else:
+            outline_checkbox_update = gr.update(
+                interactive=True,
+                info="描边仅在生成阶段生效",
+            )
+            outline_width_update = gr.update(
+                interactive=True,
+                info=None,
+            )
+            cloisonne_checkbox_update = gr.update(
+                interactive=True,
+                info="掐丝珐琅仅在生成阶段生效（与 2.5D 浮雕互斥）",
+            )
+            wire_width_update = gr.update(
+                interactive=True,
+                info=None,
+            )
+            wire_height_update = gr.update(
+                interactive=True,
+                info=None,
+            )
+
+        return (
+            cleanup_update,
+            outline_checkbox_update,
+            outline_width_update,
+            cloisonne_checkbox_update,
+            wire_width_update,
+            wire_height_update,
+        )
 
     components['radio_conv_modeling_mode'].change(
-        on_modeling_mode_change_cleanup,
+        on_modeling_mode_change_controls,
         inputs=[components['radio_conv_modeling_mode']],
-        outputs=[components['checkbox_conv_cleanup']]
+        outputs=[
+            components['checkbox_conv_cleanup'],
+            components['checkbox_conv_outline_enable'],
+            components['slider_conv_outline_width'],
+            components['checkbox_conv_cloisonne_enable'],
+            components['slider_conv_wire_width'],
+            components['slider_conv_wire_height'],
+        ]
     ).then(
         fn=save_modeling_mode,
         inputs=[components['radio_conv_modeling_mode']],
@@ -3416,7 +3551,7 @@ def create_converter_tab_content(lang: str, lang_state=None, theme_state=None) -
         from ui.palette_extension import generate_dual_recommendations_html, build_selected_dual_color_html
 
         img, display_text, hex_val, msg = on_preview_click_select_color(cache, evt)
-        if hex_val is None:
+        if hex_val is None or not isinstance(hex_val, str):
             return _preview_update(img), gr.update(), gr.update(), gr.update(), msg
 
         rec_html = ""

--- a/ui/palette_extension.py
+++ b/ui/palette_extension.py
@@ -195,8 +195,8 @@ def generate_palette_html(
 
 def build_selected_dual_color_html(quantized_hex: str = None, matched_hex: str = None, lang: str = "zh") -> str:
     """渲染“当前选中”双颜色块：量化色 + 原配准色（含下方编码）。"""
-    qh = (quantized_hex or "#000000").lower()
-    mh = (matched_hex or "#000000").lower()
+    qh = quantized_hex.lower() if isinstance(quantized_hex, str) else "#000000"
+    mh = matched_hex.lower() if isinstance(matched_hex, str) else "#000000"
 
     q_label = "量化色" if lang == "zh" else "Quantized"
     m_label = "原配准色" if lang == "zh" else "Matched"

--- a/utils/bambu_3mf_writer.py
+++ b/utils/bambu_3mf_writer.py
@@ -66,6 +66,18 @@ class BambuStudio3MFWriter:
             name: Object name (e.g., "White", "Cyan", "Magenta")
             color_rgb: RGB color tuple (0-255)
         """
+        if mesh is None:
+            raise ValueError(f"[BAMBU_3MF] Cannot add mesh '{name}': mesh is None")
+
+        vertices = getattr(mesh, "vertices", None)
+        faces = getattr(mesh, "faces", None)
+        v_count = len(vertices) if vertices is not None else 0
+        f_count = len(faces) if faces is not None else 0
+        if v_count == 0 or f_count == 0:
+            raise ValueError(
+                f"[BAMBU_3MF] Cannot add mesh '{name}': empty geometry (v={v_count}, f={f_count})"
+            )
+
         self.objects.append((mesh, name, color_rgb))
         
     def export(self):
@@ -75,6 +87,9 @@ class BambuStudio3MFWriter:
         Returns:
             str: Path to the exported 3MF file
         """
+        if len(self.objects) == 0:
+            raise ValueError("[BAMBU_3MF] Refusing to export 3MF: no mesh objects were added")
+
         print(f"[BAMBU_3MF] Exporting {len(self.objects)} objects to {self.output_path}")
         
         # Create a temporary directory for 3MF contents
@@ -553,6 +568,11 @@ def export_scene_with_bambu_metadata(scene: trimesh.Scene, output_path: str,
     Returns:
         str: Path to the exported 3MF file
     """
+    if scene is None:
+        raise ValueError("[BAMBU_3MF] Scene is None")
+    if not slot_names:
+        raise ValueError("[BAMBU_3MF] slot_names is empty - no exportable objects")
+
     # CRITICAL: Use actual number of colors, not the LUT color mode
     # This ensures filament list matches actual model parts
     num_used_colors = len(slot_names)
@@ -593,15 +613,22 @@ def export_scene_with_bambu_metadata(scene: trimesh.Scene, output_path: str,
     
     print(f"[BAMBU_3MF] Color mapping: {list(name_to_color.keys())}")
     
-    # Add each mesh from the scene IN THE ORDER OF slot_names
-    # This ensures extruder IDs match the filament list order
+    # Add each mesh from the scene IN THE ORDER OF slot_names.
+    # Use strict exact-name matching to avoid accidental substring collisions.
+    unmatched = []
     for slot_name in slot_names:
-        # Find mesh with this slot_name
-        for geom_name, mesh in scene.geometry.items():
-            if slot_name in geom_name or geom_name in slot_name:
-                color_rgb = name_to_color.get(slot_name, (200, 200, 200))
-                writer.add_mesh(mesh, geom_name, color_rgb)
-                print(f"[BAMBU_3MF] Added mesh '{geom_name}' with color {color_rgb}")
-                break
+        mesh = scene.geometry.get(slot_name)
+        if mesh is None:
+            unmatched.append(slot_name)
+            continue
+
+        color_rgb = name_to_color.get(slot_name, (200, 200, 200))
+        writer.add_mesh(mesh, slot_name, color_rgb)
+        print(f"[BAMBU_3MF] Added mesh '{slot_name}' with color {color_rgb}")
+
+    if unmatched:
+        raise ValueError(
+            "[BAMBU_3MF] Missing geometries for slot names: " + ", ".join(unmatched)
+        )
     
     return writer.export()


### PR DESCRIPTION
### 主要改动
- **矢量主链路重构（对齐 Chroma 思路）**
  - `core/vector_engine.py` 改为 shape 保序处理与逆序遮挡裁剪。
  - run-length 挤出合并连续层段，移除 micro Z-offset 依赖。
  - 引入挤出缓存、bbox 快速短路、按需拓扑修复，减少布尔/挤出开销。
  - 增加阶段耗时日志，便于性能对比与回归观测。
- **Vector 导出统一与防空模型**
  - `core/converter.py` Vector 分支统一走 `export_scene_with_bambu_metadata`。
  - 导出前增加非空校验（空 scene/空 mesh 直接失败并返回明确错误）。
  - `utils/bambu_3mf_writer.py` 增加空对象防御，mesh 匹配改为严格精确匹配。
- **前端交互稳定性修复**
  - 修复预览点击 `dict.lower` 崩溃（类型归一化 + 门禁 + 渲染兜底）。
  - `detect_image_type` 返回 `ModelingMode.VECTOR`（修复 Radio 值不匹配）。
  - Vector 模式下前端自动禁用并提示“描边/掐丝珐琅仅 Raster 生效”。
- **SVG 上传链路完善**
  - 上传预处理对 SVG 增加特判，绕开 PIL 读图错误。
  - SVG 上传时跳过 crop modal，避免无意义裁剪流程与噪声日志。
- **平台策略收敛**
  - tray 平台判定逻辑迁移至 `config.py`，`main.py` 仅调用策略。
  - Linux 默认禁用 tray（可 `ENABLE_TRAY=1` 强启），WSL 自动禁用，支持 `DISABLE_TRAY`。
  - Vector 模式下描边/掐丝珐琅当前为显式禁用（前端提示已补全），避免“参数可见但不生效”的误导。

### 测试与验证
- 单元测试：
  - `python -m pytest tests/test_vector_engine_unit.py tests/test_converter_vector_export_unit.py tests/test_preview_click_selection_unit.py -q`
  - 结果：`28 passed`
- 端到端冒烟：
  - 真实调用 `convert_image_to_3d`（Vector + SVG）成功生成 3MF/GLB。
  - 3MF 包含 `3D/3dmodel.model` 与 `3D/Objects/object_*.model`，非空导出。
 