### PR TITLE
fix(assets): unify 8-color stacks path resolution for PyInstaller

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         # 确保生成的 exe 文件名符合要求
         pyinstaller --noconfirm --onefile `
           --icon="icon.ico" `
+          --add-data "assets;assets" `
           --collect-all "gradio" `
           --collect-all "safehttpx" `
           --collect-all "groovy" `

--- a/config.py
+++ b/config.py
@@ -17,6 +17,43 @@ OUTPUT_DIR = os.path.join(_BASE_DIR, "output")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 
+def get_asset_path(relative_path: str) -> str:
+    """Resolve asset file path for both script and PyInstaller frozen modes.
+    解析资源文件路径，兼容脚本运行和 PyInstaller 打包模式。
+
+    Args:
+        relative_path (str): Relative path under assets/, e.g. 'smart_8color_stacks.npy'.
+                             (assets/ 下的相对路径)
+
+    Returns:
+        str: Absolute path to the asset file. (资源文件的绝对路径)
+
+    Raises:
+        FileNotFoundError: If the asset file cannot be found. (找不到资源文件时抛出)
+    """
+    candidates = []
+    asset_rel = os.path.join("assets", relative_path)
+
+    if getattr(sys, 'frozen', False):
+        # PyInstaller bundled: check _MEIPASS first, then CWD
+        candidates.append(os.path.join(sys._MEIPASS, asset_rel))
+        candidates.append(os.path.join(os.getcwd(), asset_rel))
+    else:
+        # Script mode: check project root, then parent dir
+        candidates.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), asset_rel))
+        candidates.append(os.path.join(os.getcwd(), asset_rel))
+        candidates.append(os.path.join("..", asset_rel))
+
+    for path in candidates:
+        if os.path.exists(path):
+            return path
+
+    raise FileNotFoundError(
+        f"Asset not found: {relative_path}\n"
+        f"Searched: {candidates}"
+    )
+
+
 class PrinterConfig:
     """Physical printer parameters (layer height, nozzle, backing)."""
     LAYER_HEIGHT: float = 0.08

--- a/core/calibration.py
+++ b/core/calibration.py
@@ -17,7 +17,7 @@ from colormath.color_objects import sRGBColor, LabColor
 from colormath.color_conversions import convert_color
 from colormath.color_diff import delta_e_cie2000
 
-from config import PrinterConfig, ColorSystem, SmartConfig, OUTPUT_DIR
+from config import PrinterConfig, ColorSystem, SmartConfig, OUTPUT_DIR, get_asset_path
 from core.naming import generate_calibration_filename
 from utils import Stats
 from utils.bambu_3mf_writer import export_scene_with_bambu_metadata
@@ -437,8 +437,7 @@ def generate_smart_board(block_size_mm=5.0, gap_mm=0.8):
 def generate_8color_board(page_index=0):
     # 1. Load Data
     try:
-        path = os.path.join("assets", "smart_8color_stacks.npy")
-        if not os.path.exists(path): path = os.path.join("..", "assets", "smart_8color_stacks.npy")
+        path = get_asset_path('smart_8color_stacks.npy')
         all_stacks = np.load(path)
         print(f"[8COLOR] Loaded {len(all_stacks)} stacks from {path}")
         

--- a/core/image_processing.py
+++ b/core/image_processing.py
@@ -11,7 +11,7 @@ import cv2
 from PIL import Image
 from scipy.spatial import KDTree
 
-from config import PrinterConfig, ModelingMode, ColorSystem
+from config import PrinterConfig, ModelingMode, ColorSystem, get_asset_path
 
 # HEIC/HEIF support (optional dependency)
 try:
@@ -255,13 +255,7 @@ class LuminaImageProcessor:
             print("[IMAGE_PROCESSOR] Detected 8-Color Max mode")
             
             # Load pre-generated 8-color stacks
-            import sys
-            if getattr(sys, 'frozen', False):
-                # Running as compiled executable
-                stacks_path = os.path.join(sys._MEIPASS, 'assets', 'smart_8color_stacks.npy')
-            else:
-                # Running as script
-                stacks_path = 'assets/smart_8color_stacks.npy'
+            stacks_path = get_asset_path('smart_8color_stacks.npy')
             
             smart_stacks = np.load(stacks_path).tolist()
             

--- a/core/lut_merger.py
+++ b/core/lut_merger.py
@@ -277,10 +277,8 @@ class LUTMerger:
             return (rgb[:min_len], _remap_stacks(stacks_arr, color_mode, lut_path))
 
         elif color_mode == "8-Color":
-            if getattr(sys, 'frozen', False):
-                stacks_path = os.path.join(sys._MEIPASS, 'assets', 'smart_8color_stacks.npy')
-            else:
-                stacks_path = 'assets/smart_8color_stacks.npy'
+            from config import get_asset_path
+            stacks_path = get_asset_path('smart_8color_stacks.npy')
             raw_stacks = np.load(stacks_path).tolist()
             # 约定转换：底到顶 → 顶到底
             stacks = [tuple(reversed(s)) for s in raw_stacks]

--- a/lumina_studio.spec
+++ b/lumina_studio.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for Lumina Studio.
+
+Usage:
+    pyinstaller lumina_studio.spec
+"""
+
+import os
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('assets', 'assets'),  # Bundle entire assets/ folder (8-color stacks etc.)
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='LuminaStudio',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon='icon.ico',
+)


### PR DESCRIPTION
- Add get_asset_path() in config.py with multi-location fallback
- Replace ad-hoc sys._MEIPASS checks in image_processing, lut_merger, calibration
- Add --add-data assets;assets to GitHub Actions build workflow
- Add lumina_studio.spec for local PyInstaller builds

Fixes: smart_8color_stacks.npy FileNotFoundError in packaged exe